### PR TITLE
feat: 加入 user 欄位與雙方信任分數邏輯

### DIFF
--- a/src/application/dto/use_tool_dto.py
+++ b/src/application/dto/use_tool_dto.py
@@ -5,6 +5,8 @@ from pydantic import BaseModel
 class UseToolRequest(BaseModel):
     game_id: str
     tool_name: str
+    user: str  # "player" 或 "agent"
+
 
 class UseToolResponse(BaseModel):
     trust_score: int

--- a/src/application/services/use_tool.py
+++ b/src/application/services/use_tool.py
@@ -6,7 +6,7 @@ from src.infrastructure.database.game_repo import GameRepository
 
 def use_tool_service(request: UseToolRequest) -> UseToolResponse:
     game = GameRepository.get(request.game_id)
-    updated_game = apply_tool_effect(game, request.tool_name)
+    updated_game = apply_tool_effect(game, request.tool_name, request.user)
     GameRepository.save(updated_game)
     
     return UseToolResponse(

--- a/src/domain/logic/tool_effect.py
+++ b/src/domain/logic/tool_effect.py
@@ -10,13 +10,20 @@ TOOL_EFFECTS = {
     "NewsLink": 0
 }
 
-def apply_tool_effect(game: GameState, tool_name: str) -> GameState:
-    # 若已使用過該工具，則不重複計算效果
-    if any(tool.name == tool_name for tool in game.tools_used):
+def apply_tool_effect(game: GameState, tool_name: str, user: str) -> GameState:
+    # 檢查是否已使用過
+    if any(tool.name == tool_name and tool.user == user for tool in game.tools_used):
         return game
 
-    # 計算效果
     delta = TOOL_EFFECTS.get(tool_name, 0)
-    game.trust_score += delta
-    game.tools_used.append(Tool(name=tool_name))
+
+    # 根據使用者更新不同的 trust_score
+    if user == "player":
+        game.trust_score_player += delta
+    elif user == "agent":
+        game.trust_score_agent += delta
+
+    # 記錄工具使用
+    game.tools_used.append(Tool(name=tool_name, user=user))
     return game
+

--- a/src/domain/models/game.py
+++ b/src/domain/models/game.py
@@ -6,9 +6,12 @@ from typing import List
 @dataclass
 class Tool:
     name: str
+    user: str
+
 
 @dataclass
 class GameState:
     id: str
-    trust_score: int
+    trust_score_player: int
+    trust_score_agent: int
     tools_used: List[Tool]


### PR DESCRIPTION
# 內容說明

- 修改 UseToolRequest DTO，加上 `user` 欄位（player / agent）
- 將 GameState 拆分為 `trust_score_player` 與 `trust_score_agent`
- 調整 tool_effect 套用邏輯，根據 user 分別影響對應 trust_score
- 更新 service 使用新的欄位與邏輯流程
