### PR TITLE
Feat/implement player turn and round flow

### DIFF
--- a/src/api/routes/base.py
+++ b/src/api/routes/base.py
@@ -116,7 +116,7 @@ def inject_service(service_class: Type[ServiceType]) -> Callable[[Session], Serv
 # 導入服務類別型別
 from src.application.services.agent_service import AgentService
 from src.application.services.news_service import NewsService
-from src.application.services.game_service import GameService, FakeNewsAgent
+from src.application.services.game_service import GameService
 from src.domain.logic.agent_factory import AgentFactory
 from src.infrastructure.database.agent_repo import AgentRepository
 from src.infrastructure.database.game_setup_repo import GameSetupRepository
@@ -145,6 +145,5 @@ def get_game_service(db: Session = Depends(get_db), agent_factory: AgentFactory 
         news_repo=NewsRepository(),
         action_repo=ActionRecordRepository(),
         round_repo=GameRoundRepository(),
-        agent=FakeNewsAgent(),
         agent_factory=agent_factory
     )

--- a/src/api/routes/games.py
+++ b/src/api/routes/games.py
@@ -4,10 +4,14 @@ Game 相關的 API 路由。
 """
 
 from fastapi import APIRouter, Depends, HTTPException, status
-from sqlalchemy.orm import Session
-
 from src.application.services.game_service import GameService
-from src.application.dto.game_dto import NewsPolishRequest, NewsPolishResponse, ArticleSubmissionResponse
+from src.application.dto.game_dto import ( 
+    NewsPolishRequest, NewsPolishResponse,
+    GameStartRequest, GameStartResponse,
+    AiTurnRequest, AiTurnResponse,
+    PlayerTurnRequest, PlayerTurnResponse,
+    StartNextRoundRequest, StartNextRoundResponse
+    )
 from src.utils.exceptions import ResourceNotFoundError, BusinessLogicError
 from src.api.routes.base import get_game_service
 
@@ -15,10 +19,25 @@ from src.api.routes.base import get_game_service
 router = APIRouter(prefix="/games", tags=["games"])
 
 
-@router.post("/start", response_model=ArticleSubmissionResponse, status_code=status.HTTP_201_CREATED)
+@router.post("/start", response_model=GameStartResponse, status_code=status.HTTP_201_CREATED)
 def start_game(service: GameService = Depends(get_game_service)):
     """
-    開始新遊戲，回傳平台初始狀態與 AI 首次假訊息。
+    ## 開始新遊戲
+    建立一場新的遊戲並初始化三個平台與受眾，預設 AI 先攻。
+
+    ### Response
+    * session_id: 遊戲識別碼（string，自動產生）
+    * round_number: 回合數（int，預設 1）
+    * actor: 行動者（"ai"）
+    * article: AI 發布的假新聞（結構見 ArticleMeta）
+    * platform_setup: 平台與受眾組合
+    * platform_status: 三平台狀態（每平台信任值、傳播率等）
+    * tool_list: 可用工具清單
+    * tool_used: 實際使用的工具（通常 AI 首回合無）
+    * effectiveness, simulated_comments: GM 模擬結果
+
+    ~~~注意~~~~
+    不需傳入任何 body，直接送 POST 請求即可。
     """
     try:
         return service.start_game()
@@ -68,4 +87,156 @@ def polish_news(
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail=f"潤稿過程發生錯誤: {str(e)}"
+        )
+        
+@router.post("/ai-turn", response_model=AiTurnResponse)
+def ai_turn(
+    request: AiTurnRequest,
+    service: GameService = Depends(get_game_service)
+):
+    """
+    ## AI 回合請求
+    由 AI 在指定 session_id 與回合數下，發布一則新聞，由 GameMaster 評分。
+
+    ### Request Body
+    * session_id: 遊戲識別碼（string，必填）
+    * round_number: 回合數（int，必填）
+
+    ### Response : 回傳內容同 /games/start，actor 皆為 "ai" 
+    * session_id: 遊戲識別碼（string，自動產生）
+    * round_number: 回合數（int，預設 1）
+    * actor: 行動者（"ai"）
+    * article: AI 發布的假新聞（結構見 ArticleMeta）
+    * platform_setup: 平台與受眾組合
+    * platform_status: 三平台狀態（每平台信任值、傳播率等）
+    * tool_list: 可用工具清單
+    * tool_used: 實際使用的工具（通常 AI 首回合無）
+    * effectiveness, simulated_comments: GM 模擬結果
+
+    ### 常見錯誤
+    * 請確保 session_id 與 round_number 有對應的遊戲狀態，否則會回 404。
+    """
+    try:
+        return service.ai_turn(request)
+    except ResourceNotFoundError as e:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=str(e)
+        )
+    except BusinessLogicError as e:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=str(e)
+        )
+    except Exception as e:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=f"AI 回合過程發生錯誤: {str(e)}"
+        )
+
+@router.post("/player-turn", response_model=PlayerTurnResponse)
+def player_turn(
+    request: PlayerTurnRequest,
+    service: GameService = Depends(get_game_service)
+):
+    """
+    ## 玩家回合請求
+    玩家於指定 session_id 與 round_number，提交一則新聞（查核、澄清、附和等皆可），可選擇同時使用工具。
+    系統會依據玩家提交內容與使用工具，由 GameMaster 判斷效果與分數。
+
+    ### Request Body
+    * session_id: 遊戲識別碼（string，必填）
+    * round_number: 回合數（int，必填）
+    * article: 玩家發布的新聞內容（object，必填，結構如下）
+        - title: 文章標題（string，必填）
+        - content: 原始內容（string，必填）
+        - author: 發文者名稱（string，必填，通常為玩家名稱）
+        - published_date: 發布時間（string，必填，ISO 格式，如 "2025-05-21T14:45:00"）
+        - target_platform: 文章發佈的平台（string，必填）
+        - polished_content: 潤稿後內容（string，選填，若有使用工具可填入）
+        - image_url: 配圖連結（string，選填，預設為 null）
+        - source: 新聞來源（string，選填，預設為 null）
+        - requirement: 風格或語氣需求（string，選填）
+        - veracity: 真實性標註（string，選填，由後端填入，前端可省略）
+    * tool_used: 玩家實際使用的工具（list，選填，預設為空）
+    * tool_list: 可用工具清單（list，選填，由後端傳，前端可省略）
+
+    ### Response
+    回傳本回合所有判定結果（同 ai-turn），actor 皆為 "player"。
+    * session_id: 遊戲識別碼（string）
+    * round_number: 回合數（int）
+    * actor: 行動者（"player"）
+    * article: 本回合玩家發布的新聞內容（object，結構如 ArticleMeta）
+    * platform_setup: 平台與受眾組合
+    * platform_status: 三平台狀態（每平台信任值、傳播率等）
+    * tool_list: 可用工具清單
+    * tool_used: 本回合實際使用的工具
+    * effectiveness: GM 模擬評分（"low"/"medium"/"high"）
+    * simulated_comments: GM 模擬社群留言
+
+    ~~~注意~~~
+    欄位如未使用可設為 null 或留空，後端會自動處理。
+    """
+    try:
+        return service.player_turn(request)
+    except ResourceNotFoundError as e:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=str(e)
+        )
+    except BusinessLogicError as e:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=str(e)
+        )
+    except Exception as e:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=f"玩家回合過程發生錯誤: {str(e)}"
+        )
+
+@router.post("/next-round", response_model=StartNextRoundResponse)
+def start_next_round(
+    request: StartNextRoundRequest,
+    service: GameService = Depends(get_game_service)
+):
+    """
+    ## 進入下一回合
+    進行新一輪遊戲，由 AI 先攻。系統自動判斷目前最大回合數，自動 +1，產生新回合，並由 AI 發布假新聞。
+
+    ### Request Body
+    * session_id: 遊戲識別碼（string，必填）
+
+    ### Response : 回傳本回合所有資料，結構同 ai-turn，actor 為 "ai"。
+    * session_id: 遊戲識別碼（string）
+    * round_number: 回合數（int，自動加 1）
+    * actor: 行動者（"ai"）
+    * article: AI 發布的假新聞內容（object，見 ArticleMeta 結構）
+    * platform_setup: 平台與受眾組合
+    * platform_status: 三平台狀態（每平台信任值、傳播率等）
+    * tool_list: 可用工具清單
+    * tool_used: 本回合實際使用的工具
+    * effectiveness: GM 模擬評分
+    * simulated_comments: GM 模擬社群留言
+
+    ~~~注意~~~
+    前端僅需傳入 session_id，後端自動判斷回合序號。
+    """
+
+    try:
+        return service.start_next_round(request)
+    except ResourceNotFoundError as e:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=str(e)
+        )
+    except BusinessLogicError as e:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=str(e)
+        )
+    except Exception as e:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=f"切換回合過程發生錯誤: {str(e)}"
         )

--- a/src/api/routes/games.py
+++ b/src/api/routes/games.py
@@ -7,7 +7,7 @@ from fastapi import APIRouter, Depends, HTTPException, status
 from sqlalchemy.orm import Session
 
 from src.application.services.game_service import GameService
-from src.application.dto.game_dto import GameStartResponse, NewsPolishRequest, NewsPolishResponse
+from src.application.dto.game_dto import NewsPolishRequest, NewsPolishResponse, ArticleSubmissionResponse
 from src.utils.exceptions import ResourceNotFoundError, BusinessLogicError
 from src.api.routes.base import get_game_service
 
@@ -15,7 +15,7 @@ from src.api.routes.base import get_game_service
 router = APIRouter(prefix="/games", tags=["games"])
 
 
-@router.post("/start", response_model=GameStartResponse, status_code=status.HTTP_201_CREATED)
+@router.post("/start", response_model=ArticleSubmissionResponse, status_code=status.HTTP_201_CREATED)
 def start_game(service: GameService = Depends(get_game_service)):
     """
     開始新遊戲，回傳平台初始狀態與 AI 首次假訊息。

--- a/src/application/dto/game_dto.py
+++ b/src/application/dto/game_dto.py
@@ -6,69 +6,28 @@ Game 相關的 DTO (Data Transfer Objects)。
 from typing import List, Dict, Any, Optional
 from pydantic import BaseModel, Field
 
-
 class PlatformStatus(BaseModel):
     """
     回傳每個平台當前狀態（初始化時由 DB 取得 PlatformState 轉換而來）
     """
-    platform: str = Field(..., description="平台名稱，例如 Facebook、Twitter")
-    player_trust: int = Field(..., description="玩家在此平台的信任值（0-100）")
-    ai_trust: int = Field(..., description="AI 在此平台的信任值（0-100）")
-    spread: int = Field(..., description="此平台的訊息傳播率（例如 65 表示 65%）")
-
-    class Config:
-        json_schema_extra = {
-            "example": {
-                "platform": "Facebook",
-                "player_trust": 50,
-                "ai_trust": 45,
-                "spread": 65
-            }
-        }
-
-
-class GameStartResponse(BaseModel):
-    """
-    遊戲初始化後回傳給前端的資料格式
-    """
-    session_id: str = Field(..., description="遊戲識別碼，例如 game_12345")
-    platforms: List[PlatformStatus] = Field(..., description="每個平台的狀態資訊")
-    first_news: str = Field(..., description="第一則 AI 發出的假訊息標題（非全文）")
-    ai_platform: str = Field(..., description="AI 在哪個平台發佈該訊息")
-    trust_change: int = Field(..., description="該訊息造成的信任值變化（例如 +8）")
-    spread_change: int = Field(..., description="該訊息造成的傳播率變化（例如 +12）")
+    session_id: Optional[str] = Field(None, description="遊戲識別碼")
+    round_number: Optional[int] = Field(None, description="回合數")
+    platform_name: Optional[str] = Field(None, description="平台名稱，例如 Facebook, Instagram, Thread")
+    player_trust: Optional[int] = Field(None, description="玩家在此平台的信任值（0-100）")
+    ai_trust: Optional[int] = Field(None, description="AI 在此平台的信任值（0-100）")
+    spread_rate: Optional[int] = Field(None, description="此平台的訊息傳播率（例如 65 表示 65%）")
 
     class Config:
         json_schema_extra = {
             "example": {
                 "session_id": "game_12345",
-                "platforms": [
-                    {
-                        "platform": "Facebook",
-                        "player_trust": 50,
-                        "ai_trust": 45,
-                        "spread": 65
-                    },
-                    {
-                        "platform": "Instagram",
-                        "player_trust": 55,
-                        "ai_trust": 50,
-                        "spread": 70
-                    },
-                    {
-                        "platform": "Twitter",
-                        "player_trust": 60,
-                        "ai_trust": 55,
-                        "spread": 75
-                    }
-                ],
-                "first_news": "AI 發佈的假訊息標題",
-                "ai_platform": "Facebook",
-                "trust_change": 8,
-                "spread_change": 12
+                "round_number": 1,
+                "platform_name": "Facebook",
+                "player_trust": 50,
+                "ai_trust": 45,
+                "spread_rate": 65
             }
         }
-
 
 class NewsPolishRequest(BaseModel):
     """
@@ -102,5 +61,113 @@ class NewsPolishResponse(BaseModel):
                     "建議加入未來淨灘活動資訊"
                 ],
                 "reasoning": "修改重點包括：加入吸引人的標題、使用更生動的描述語言、強調環保意識、突出成就感與使命感。"
+            }
+        }
+
+class FakeNewsAgentRequest(BaseModel):
+    """
+    假新聞生成請求 DTO
+    """
+    session_id: str = Field(..., description="遊戲 ID")  
+    round_number: int = Field(..., description="回合數")
+
+class ArticleMeta(BaseModel):
+    """
+    文章的基本資訊欄位
+    """
+    title: str = Field(..., description="文章標題")  
+    content: str = Field(..., description="原始內容") 
+    polished_content: Optional[str] = Field(None, description="潤稿後的內容（僅玩家使用工具時提供）")
+    image_url: Optional[str] = Field(None, description="配圖連結") 
+    source: Optional[str] = Field(None, description="新聞來源")
+    author: str = Field(..., description="發文者名稱，ai 或 玩家名稱")
+    published_date: str = Field(..., description="發布時間，例如 2024-05-18T15:30:00")
+    target_platform: Optional[str] = Field(None, description="文章發佈的平台（AI 回合不顯示）")
+    requirement: Optional[str] = Field(None, description="語氣或風格需求（如有）")
+    veracity: Optional[str] = Field(None, description="AI 生成文章的真實性，由 AI 自己判斷")
+        
+class ArticleSubmissionResponse(BaseModel):
+    """
+    發布新聞後的回應
+    """
+    session_id: str = Field(..., description="遊戲識別碼")
+    round_number: int = Field(..., description="回合數")
+    actor: str = Field(..., description="ai / player")
+    article: ArticleMeta = Field(..., description="實際發文的內容")
+    trust_change: int = Field(..., description="這回合造成的信任值變化")
+    reach_count: int = Field(..., description="這回合的觸及人數")
+    spread_change: int = Field(..., description="這回合造成的傳播率變化")
+    platform_setup: List[dict] = Field(..., description="平台+受眾組合")
+    platform_status: List[PlatformStatus] = Field(..., description="所有平台目前的狀態")
+    effectiveness: Optional[str] = Field(None, description="GM 評定效果（low / medium / high）")
+    simulated_comments: Optional[List[str]] = Field(None, description="模擬社群留言，JSON 陣列")
+    tool_used: Optional[List[Dict[str, Any]]] = Field(None, description="實際使用的工具")
+    tool_list: List[Dict[str, Any]] = Field(..., description="所有工具的名稱、描述及啟用狀況")
+    
+    class Config:
+        json_schema_extra = {
+            "example": {
+                "session_id": "game_123456",
+                "round_number": 2,
+                "actor": "ai",
+                "article": {
+                    "title": "震驚！地球即將進入極端氣候新紀元",
+                    "content": "新研究指出...",
+                    "polished_content": None,
+                    "image_url": "https://example.com/image.jpg",
+                    "source": "虛構新聞社",
+                    "author": "ai",
+                    "published_date": "2025-05-18T15:00:00",
+                    "target_platform": "Facebook",
+                    "requirement": None,
+                    "veracity": None
+                },
+                "trust_change": 8,
+                "reach_count": 1200,
+                "spread_change": 12,
+                "platform_setup": [
+                    {"name": "Facebook", "audience": "年輕族群"},
+                    {"name": "Instagram", "audience": "中年族群"},
+                    {"name": "Thread", "audience": "老年族群"}
+                ],
+                "platform_status": [
+                    {
+                        "session_id": "game_123456",
+                        "round_number": 2,
+                        "platform_name": "Facebook",
+                        "player_trust": 50,
+                        "ai_trust": 45,
+                        "spread_rate": 65
+                    },
+                    {
+                        "session_id": "game_123456",
+                        "round_number": 2,
+                        "platform_name": "Instagram",
+                        "player_trust": 55,
+                        "ai_trust": 50,
+                        "spread_rate": 70
+                    },
+                    {
+                        "session_id": "game_123456",
+                        "round_number": 2,
+                        "platform_name": "Twitter",
+                        "player_trust": 60,
+                        "ai_trust": 55,
+                        "spread_rate": 75
+                    }
+                ],
+                "effectiveness": "high",
+                "simulated_comments": [
+                    "這新聞太誇張了吧！",
+                    "真的假的？",
+                    "我覺得有點唬爛"
+                ],
+                "tool_used": [
+                    {"tool_name": "情緒強化器", "effect": "increase_trust"}
+                ],
+                "tool_list": [
+                    {"tool_name": "情緒強化器", "description": "提升情緒感染力"},
+                    {"tool_name": "語氣轉換器", "description": "模仿年輕族群語氣"}
+                ]
             }
         }

--- a/src/application/services/game_service.py
+++ b/src/application/services/game_service.py
@@ -7,8 +7,9 @@ from typing import List, Optional, Dict, Any
 import random
 import uuid
 import json
+import datetime
 
-from src.application.dto.game_dto import GameStartResponse, PlatformStatus, NewsPolishRequest, NewsPolishResponse
+from src.application.dto.game_dto import PlatformStatus, NewsPolishRequest, NewsPolishResponse, ArticleSubmissionResponse, FakeNewsAgentRequest, ArticleMeta
 from src.infrastructure.database.game_setup_repo import GameSetupRepository
 from src.infrastructure.database.platform_state_repo import PlatformStateRepository
 from src.infrastructure.database.news_repo import NewsRepository
@@ -18,14 +19,6 @@ from src.domain.logic.agent_factory import AgentFactory
 from src.utils.exceptions import BusinessLogicError, ResourceNotFoundError
 from src.utils.logger import logger
 
-# 先用 stub 代替 FakeNewsAgent
-#from src.infrastructure.agents.fake_news_agent import FakeNewsAgent
-
-# 這裡是 stub 的 FakeNewsAgent
-class FakeNewsAgent:
-    def generate_fake_news(self, news):
-        return f"[FAKE] {news.title}"
-        # 這裡省略了 Agent 的其他屬性
         
 class GameService:
     """
@@ -39,8 +32,8 @@ class GameService:
         news_repo: NewsRepository,
         action_repo: ActionRecordRepository,
         round_repo: GameRoundRepository,
-        agent: FakeNewsAgent,
-        agent_factory: Optional[AgentFactory] = None
+        agent_factory: Optional[AgentFactory] = None,
+        tools_repo: Optional[Any] = None
     ):
         """
         初始化服務。
@@ -51,7 +44,6 @@ class GameService:
             news_repo: News 的 Repository
             action_repo: ActionRecord 的 Repository
             round_repo: GameRound 的 Repository
-            agent: 假新聞生成 Agent
             agent_factory: Agent 工廠，用於潤稿功能
         """
         self.setup_repo = setup_repo
@@ -59,95 +51,96 @@ class GameService:
         self.news_repo = news_repo
         self.action_repo = action_repo
         self.round_repo = round_repo
-        self.agent = agent
         self.agent_factory = agent_factory
+        self.tools_repo = tools_repo
 
-    def start_game(self) -> GameStartResponse:
+    def start_game(self) -> ArticleSubmissionResponse:
         """
-        遊戲初始化服務：建立初始設定、平台狀態、AI 行動與第一回合記錄。
-
+        開始遊戲，初始化遊戲狀態。
+        1. 產生唯一的 session_id
+        2. 隨機產生三個平台與受眾的組合
+        3. 建立 GameSetup 紀錄
+        4. 建立第一回合的 PlatformState 紀錄
+        5. 建立第一回合的 GameRound 紀錄
+        6. 呼叫 AI 進行第一回合的操作    
+    
         Returns:
-            GameStartResponse: 遊戲初始化的響應 DTO
+            GameStartResponse: 回傳本次遊戲初始化與第一回合 AI 行動的所有資訊，欄位如下：
+    
+            - session_id: 遊戲識別碼
+            - round_number: 回合數（預設為 1）
+            - article: ArticleMeta，AI 發布的假新聞內容
+            - actor: 本回合行動者（"ai"）
+            - trust_change: 本回合造成的信任值變化
+            - reach_count: 本回合的觸及人數
+            - spread_change: 本回合造成的傳播率變化
+            - platform_setup: 平台與受眾的組合（初始化時的 platforms）
+            - platform_status: 所有平台目前的狀態（信任值、傳播率等）
+            - tool_list: 所有可用工具的名稱、描述及啟用狀況
+            - tool_used: 本回合實際使用的工具（如有）
+
         """
-        # 1. 隨機產生 platform 與 audience 組合
-        platform_names = ["Facebook", "Instagram", "Twitter"]
-        audiences = ["學生", "年輕族群", "中年族群"]
+        # 產生唯一 session_id
+        session_id = f"game_{uuid.uuid4().hex}"
+        round_number = 1 # 第一回合
+        
+        # 隨機產生 platform 與 audience 組合
+        platform_names = ["Facebook", "Instagram", "Thread"]
+        audiences = ["年輕族群", "中年族群", "老年族群"]
         random.shuffle(audiences)
 
         platforms = [{"name": name, "audience": audience} for name, audience in zip(platform_names, audiences)]
+        
+        # 建立 GameSetup 紀錄
+        self.setup_repo.create_game_setup(
+            session_id=session_id, 
+            platforms=platforms, 
+            player_initial_trust=50, 
+            ai_initial_trust=50
+            )
 
-        # 產生唯一 session_id
-        session_id = f"game_{uuid.uuid4().hex}"
-
-        # 2. 建立 GameSetup
-        self.setup_repo.create_game_setup(session_id=session_id, platforms=platforms)
-
-        # 3. 建立 PlatformState（信任值預設 50）
-        self.state_repo.create_initial_states(session_id=session_id, platforms=platforms)
-
-        # 4. 隨機選一則新聞
-        news = self.news_repo.get_random_news()
-
-        # 5. 呼叫 FakeNewsAgent，產出訊息（假訊息或轉述）
-        ai_platform = platforms[0]["name"]
-        fake_content = self.agent.generate_fake_news(news)
-
-        # 6. 建立 AI 的 ActionRecord
-        action = self.action_repo.create_action_record(
+        # 建立第一回合 PlatformState（玩家信任值, AI 信任值, 傳播率皆預設 50）
+        self.state_repo.create_all_platforms_states(
             session_id=session_id,
-            round_number=1,
-            actor="ai",
-            platform=ai_platform,
-            content=fake_content
-        )
-
-        # 7. GM 評分結果（stub）
-        trust_delta = +8
-        spread_delta = +12
-        self.action_repo.update_effectiveness(
-            action_id=action.id,
-            trust_change=trust_delta,
-            spread_change=spread_delta,
-            effectiveness="Medium",
-            reach_count=800
-        )
-
-        # 8. 更新 PlatformState
-        self.state_repo.update_platform_state(
-            session_id=session_id,
-            round_number=1,
-            platform_name=ai_platform,
-            trust_change_ai=trust_delta,
-            spread_change=spread_delta
-        )
-
-        # 9. 建立第一回合
-        self.round_repo.create_first_round(
-            session_id=session_id,
-            round_number=1,
-            news_id=news.news_id
-        )
-
-        # 10. 回傳 DTO
-        platform_states = self.state_repo.get_states_by_session(session_id)
-        dto_platforms: List[PlatformStatus] = [
-            PlatformStatus(
-                platform=s.platform_name,
-                player_trust=s.player_trust,
-                ai_trust=s.ai_trust,
-                spread=s.spread_rate
-            ) for s in platform_states
-        ]
-
-        return GameStartResponse(
-            session_id=session_id,
-            platforms=dto_platforms,
-            first_news=news.title,
-            ai_platform=ai_platform,
-            trust_change=trust_delta,
-            spread_change=spread_delta
+            round_number=round_number,
+            platforms=platforms,  # 這是一個 list of dict，例如 [{"name": "Facebook"}, ...]
+            player_trust=50,
+            ai_trust=50,
+            spread_rate=50
         )
         
+        # 建立第一回合 GameRound 紀錄
+        self.round_repo.create_game_round(
+            session_id=session_id,
+            round_number=round_number,
+            is_completed=False
+        )
+              
+        # 呼叫 AI 回合
+        ai_request = FakeNewsAgentRequest(
+            session_id=session_id,
+            round_number=round_number,
+        )
+        ai_response = self.ai_turn(ai_request)
+
+        # 組成 ArticleSubmissionResponse
+        return ArticleSubmissionResponse(
+            session_id=ai_response.session_id,
+            round_number=round_number,
+            article=ai_response.article,
+            actor=ai_response.actor,
+            trust_change=ai_response.trust_change,
+            reach_count=ai_response.reach_count,
+            spread_change=ai_response.spread_change,
+            platform_setup=platforms,  # 這是初始化時的 platforms
+            platform_status=ai_response.platform_status,
+            tool_list=ai_response.tool_list,
+            tool_used=ai_response.tool_used,
+            effectiveness=ai_response.effectiveness,
+            simulated_comments=ai_response.simulated_comments
+        )
+
+                
     def polish_news(self, request: NewsPolishRequest) -> NewsPolishResponse:
         """
         使用 AI 系統當物潤稿新聞內容。
@@ -194,8 +187,7 @@ class GameService:
             result = self.agent_factory.run_agent_by_name(
                 session_id=request.session_id,
                 agent_name="news_polish_agent", 
-                variables=variables,
-                input_text=request.requirements
+                variables=variables
             )
             
             # 當用 structured_output 時，有可能是字典或JSON字符串
@@ -244,3 +236,355 @@ class GameService:
         except Exception as e:
             # 其他錯誤
             raise BusinessLogicError(f"潤稿過程發生錯誤: {str(e)}")
+
+
+    def ai_turn(self, request: FakeNewsAgentRequest) -> ArticleSubmissionResponse:
+        """
+        AI 回合主流程：生成假新聞，評分並更新狀態，最後回傳本回合結果。
+    
+        Args:
+            request: FakeNewsAgentRequest
+                - session_id: 遊戲識別碼
+                - round_number: 回合數
+                - tool_list: 可選，AI 可用的工具清單（通常由後端自動取得）
+    
+        Returns:
+            ArticleSubmissionResponse: 本回合的回傳資料，包含以下欄位：
+                - session_id: 遊戲識別碼
+                - round_number: 回合數
+                - actor: 行動者（"ai"）
+                - article: ArticleMeta，AI 發布的假新聞內容
+                - trust_change: 本回合造成的信任值變化
+                - reach_count: 本回合的觸及人數
+                - spread_change: 本回合造成的傳播率變化
+                - platform_setup: 平台與受眾的組合（初始化時的 platforms）
+                - platform_status: 所有平台目前的狀態（信任值、傳播率等）
+                - tool_list: 所有可用工具的名稱、描述及啟用狀況
+                - tool_used: 本回合實際使用的工具（如有）
+    
+        流程說明：
+            1. 隨機選擇一個平台與受眾組合
+            2. 隨機選取兩則新聞作為生成素材
+            3. 整理可用工具描述
+            4. 呼叫 FakeNewsAgent 產生假新聞
+            5. 建立 AI 的 ActionRecord
+            6. 呼叫 game_master() 進行評分
+            7. 更新 ActionRecord 與 PlatformState
+            8. 回傳本回合所有資訊
+        """
+        if not self.agent_factory:
+            raise BusinessLogicError("系統未設定 Agent Factory")
+        session_id = request.session_id
+        if session_id is None:
+            raise BusinessLogicError("session_id 必須由前端傳入")
+        round_number = request.round_number
+        if round_number is None:
+            raise BusinessLogicError("round_number 必須由前端傳入")
+        
+         # 2. 取得三平台設定，隨機選一組
+        platforms_info = self.setup_repo.get_by_session_id(session_id).platforms
+        ai_platform_info = random.choice(platforms_info)
+        ai_platform = ai_platform_info["name"]
+        target_audience = ai_platform_info["audience"]
+
+         # 3. 隨機選兩則新聞，取得 veracity
+        news_1 = self.news_repo.get_random_active_news()
+        news_2 = self.news_repo.get_random_active_news()
+
+        # 4. 準備工具描述（applicable_to in ["ai", "both"]）
+        # TODO: 這邊要從 tools_repo 取得所有可用工具
+        """
+        if hasattr(self, 'tools_repo') and self.tools_repo is not None:
+            all_tools = self.tools_repo.get_all_tools()
+            tool_used = [tool for tool in all_tools if tool.get("applicable_to") in ["ai", "both"]]
+            used_tool_descriptions = ", ".join([t.get("description") for t in tool_used if t.get("description")])
+        else:
+            all_tools = []
+            tool_used = []
+            used_tool_descriptions = "無可用工具"
+        """
+        # all_tools, tool_used 先設為空的
+        all_tools = []
+        tool_used = []
+        used_tool_descriptions = "無可用工具" # 暫時先用這個
+       
+        # 5. 準備 FakeNewsAgent prompt 變數
+        variables = {
+            "news_1": news_1.content,
+            "news_1_veracity": news_1.veracity,
+            "news_2": news_2.content,
+            "news_2_veracity": news_2.veracity,
+            "target_platform": ai_platform,
+            "target_audience": target_audience,
+            "used_tool_descriptions": used_tool_descriptions
+        }
+
+        # 6. 呼叫 FakeNewsAgent 產生假新聞
+        try:
+            result = self.agent_factory.run_agent_by_name(
+            session_id=session_id,
+            agent_name="fake_news_agent",
+            variables=variables
+            )
+
+            # 統一解析 output
+            if isinstance(result, dict):
+                result_data = result
+            elif isinstance(result, str):
+                try:
+                    result_data = json.loads(result)
+                except Exception:
+                    raise BusinessLogicError("FakeNewsAgent 回傳格式錯誤，無法解析 JSON")
+            else:
+                raise BusinessLogicError("FakeNewsAgent 回傳了不支援的格式")
+
+            # 7. 組成 ArticleMeta
+            article = ArticleMeta(
+                title=result_data.get("title"),
+                content=result_data.get("content"),
+                polished_content=None,
+                image_url=result_data.get("image_url"),
+                source=news_1.source, # 只給一個
+                author="ai",
+                published_date=datetime.now().isoformat(),
+                target_platform=ai_platform,  
+                requirement=None,
+                veracity=result_data.get("veracity")  
+            )
+        except ResourceNotFoundError:
+            raise ResourceNotFoundError(
+                message="找不到 FakeNewsAgent",
+                resource_type="agent",
+                resource_id="FakeNewsAgent"
+            )
+        except Exception as e:
+            raise BusinessLogicError(f"生成假新聞過程發生錯誤: {str(e)}")
+
+        # 8. 建立 AI 的 ActionRecord（僅初步，之後補全）
+        action = self.action_repo.create_action_record(
+            session_id=session_id,
+            round_number=round_number,
+            actor="ai",
+            platform=ai_platform,
+            content=article.content
+        )
+        
+        # 更新 GameRound 的 news_id
+        self.round_repo.update_game_round(
+            session_id=session_id,
+            round_number=round_number,
+            news_id=news_1.news_id,  # 使用第一則新聞的 ID
+        )
+        
+        # 工具倍率計算（由你設計規則，這裡範例直接設 1.0）
+        trust_multiplier = 1.0  # TODO: 根據工具選擇計算
+        spread_multiplier = 1.0  # TODO: 根據工具選擇計算
+        
+        # TODO: AI 的 UsageTool 紀錄還沒弄~~~~~~~
+
+        # 9. 呼叫 game_master() 評分
+        gm_result = self.game_master(
+            session_id=session_id,
+            round_number=round_number,
+            article=article,
+            platform=ai_platform,
+            trust_multiplier=trust_multiplier,
+            spread_multiplier=spread_multiplier            
+        )
+        
+        trust_change = gm_result["trust_change"]
+        spread_change = gm_result["spread_change"]
+        reach_count = gm_result["reach_count"]
+        platform_status = gm_result["platform_status"]
+        effectiveness = gm_result.get("effectiveness")
+        simulated_comments = gm_result.get("simulated_comments")
+
+        # 10. 更新 AI ActionRecord：補上 GM 結果
+        self.action_repo.update_effectiveness(
+            action_id=action.id,
+            trust_change=trust_change,
+            spread_change=spread_change,
+            reach_count=reach_count,
+            effectiveness=effectiveness,
+            simulated_comments=simulated_comments
+        )
+
+        # 11. 更新 PlatformState（只針對三平台同步更新，根據 GM 回傳結果）
+        for state in platform_status:
+            self.state_repo.update_platform_state(
+                session_id=session_id,
+                round_number=round_number,
+                platform_name=state["platform_name"],
+                ai_trust=state["ai_trust"],  
+                spread_rate=state["spread"]       
+            )
+        
+        # 將 platform_status 轉換為 PlatformStatus 物件
+        platform_status_objs = [self.platform_status_from_dict(ps) for ps in platform_status]
+        
+        # 過濾 target_platform 跟 veracity
+        article_dict = article.model_dump()
+        article_dict["target_platform"] = None
+        article_dict["veracity"] = None
+        article_safe = ArticleMeta.model_validate(article_dict)
+
+        # 12. 組成 ArticleSubmissionResponse，回傳本回合所有欄位
+        return ArticleSubmissionResponse(
+            session_id=session_id,
+            round_number=round_number,
+            actor="ai",
+            article=article_safe,
+            trust_change=trust_change,
+            reach_count=reach_count,
+            spread_change=spread_change,
+            platform_setup=self.setup_repo.get_by_session_id(session_id).platforms,  # 取得平台+受眾組合
+            platform_status=platform_status_objs,
+            tool_used=tool_used,
+            tool_list=all_tools,
+            effectiveness=effectiveness,
+            simulated_comments=simulated_comments
+        )
+
+    def game_master(
+        self,   
+        session_id: str,
+        round_number: int,
+        article: ArticleMeta,
+        platform: str,
+        trust_multiplier: float = 1.0,
+        spread_multiplier: float = 1.0,
+    ) -> dict:
+        """
+        GameMaster：僅負責計算/回傳評分，不做任何 DB 寫入。
+    
+        Args:
+            session_id: 遊戲場次 ID
+            round_number: 回合數
+            article: ArticleMeta（本回合發文的所有欄位）
+            platform: 本回合發文的平台名稱
+            trust_multiplier: 工具倍率，影響信任值變化
+            spread_multiplier: 工具倍率，影響傳播率變化
+    
+        Returns:
+            dict: 包含本回合評分結果，格式如下：
+                {
+                    "trust_change": int,         # 本回合造成的信任值變化
+                    "spread_change": int,        # 本回合造成的傳播率變化
+                    "reach_count": int,          # 本回合的觸及人數
+                    "platform_status": [         # 各平台最新狀態
+                        {
+                            "platform_name": str,
+                            "player_trust": int,
+                            "ai_trust": int,
+                            "spread": int
+                        },
+                        ...
+                    ]
+                }
+    
+        流程說明：
+            1. 取得三平台與受眾組合
+            2. 取得三平台當前狀態
+            3. 組成平台摘要字串，傳給 GM agent
+            4. 呼叫 GameMaster agent 進行評分
+            5. 解析回傳結果，回傳評分與平台狀態
+        """  
+        
+        if not self.agent_factory:
+            raise BusinessLogicError("系統未設定 Agent Factory")
+    
+        # === 從 GameSetup 撈出三個平台與對應受眾 ===
+        game_setup = self.setup_repo.get_by_session_id(session_id)
+        platforms_info = game_setup.platforms  # JSON 欄位：list of {"name": ..., "audience": ...}
+        audience_map = {p["name"]: p["audience"] for p in platforms_info}
+
+        # === 撈出三個平台當前狀態 ===
+        platform_states = self.state_repo.get_by_session_and_round(
+            session_id=session_id,
+            round_number=round_number
+        )
+
+        # === 組成平台摘要字串給 agent 參考（含受眾）===
+        platform_state_summary = "\n".join([
+            f"{s.platform_name}（受眾：{audience_map.get(s.platform_name)}） | 玩家信任: {s.player_trust} | AI信任: {s.ai_trust} | 傳播率: {s.spread_rate}%"
+            for s in platform_states
+        ])
+
+        if article.polished_content:
+            article.content = article.polished_content
+
+        # === 準備傳給 GM agent 的變數 ===
+        variables = {
+            "title": article.title,
+            "content": article.content,
+            "image_url": article.image_url,
+            "source": article.source,
+            "veracity": article.veracity,
+            "target_platform": platform,
+            "author": article.author,
+            "trust_multiplier": trust_multiplier,
+            "spread_multiplier": spread_multiplier,
+            "platform_state_summary": platform_state_summary,
+            "round_number": round_number
+        }
+
+        # === 呼叫 GameMaster Agent 評分 ===
+        try:
+            result = self.agent_factory.run_agent_by_name(
+                session_id=session_id,
+                agent_name="game_master_agent",
+                variables=variables
+            )
+
+            # 嘗試解析回傳 JSON 結果
+            if isinstance(result, str):
+                result_data = json.loads(result)
+            elif isinstance(result, dict):
+                result_data = result
+            else:
+                raise BusinessLogicError("GameMasterAgent 回傳格式錯誤，無法辨識")
+
+            # === 提取回傳數值 ===
+            trust_change = result_data.get("trust_change", 0)
+            spread_change = result_data.get("spread_change", 0)
+            reach_count = result_data.get("reach_count", 0)
+            new_platform_statuses = result_data.get("platform_status", [])  # 應為三筆 dict
+            effectiveness = result_data.get("effectiveness")
+            simulated_comments = result_data.get("simulated_comments")
+
+            # 檢查每筆 platform_status 必含 platform_name
+            for ps in new_platform_statuses:
+                assert "platform_name" in ps and "player_trust" in ps and "ai_trust" in ps and "spread" in ps, \
+                    "platform_status 每筆需有 platform_name, player_trust, ai_trust, spread"
+
+            # === 回傳結果 ===
+            return {
+                "trust_change": trust_change,
+                "spread_change": spread_change,
+                "reach_count": reach_count,
+                "platform_status": new_platform_statuses,
+                "effectiveness": effectiveness,
+                "simulated_comments": simulated_comments
+            }
+
+        except ResourceNotFoundError:
+            raise ResourceNotFoundError(
+                message="找不到 GameMasterAgent",
+                resource_type="agent",
+                resource_id="GameMasterAgent"
+            )
+
+        except Exception as e:
+            raise BusinessLogicError(f"GameMaster 評分過程發生錯誤: {str(e)}")
+
+    @staticmethod
+    def platform_status_from_dict(ps: dict) -> PlatformStatus:
+        return PlatformStatus(
+            platform_name=ps["platform_name"],
+            player_trust=ps["player_trust"],
+            ai_trust=ps["ai_trust"],
+            spread_rate=ps["spread"]
+        )
+        """
+        將平台狀態字典轉換為 PlatformStatus 物件。
+        """

--- a/src/application/services/game_service.py
+++ b/src/application/services/game_service.py
@@ -7,9 +7,18 @@ from typing import List, Optional, Dict, Any
 import random
 import uuid
 import json
-import datetime
+from datetime import datetime
+import re
 
-from src.application.dto.game_dto import PlatformStatus, NewsPolishRequest, NewsPolishResponse, ArticleSubmissionResponse, FakeNewsAgentRequest, ArticleMeta
+from src.application.dto.game_dto import (
+    PlatformStatus, 
+    NewsPolishRequest, NewsPolishResponse,
+    GameStartRequest, GameStartResponse,
+    AiTurnRequest, AiTurnResponse,
+    PlayerTurnRequest, PlayerTurnResponse,
+    StartNextRoundRequest, StartNextRoundResponse,
+    ArticleMeta, ToolUsed
+    )
 from src.infrastructure.database.game_setup_repo import GameSetupRepository
 from src.infrastructure.database.platform_state_repo import PlatformStateRepository
 from src.infrastructure.database.news_repo import NewsRepository
@@ -19,6 +28,14 @@ from src.domain.logic.agent_factory import AgentFactory
 from src.utils.exceptions import BusinessLogicError, ResourceNotFoundError
 from src.utils.logger import logger
 
+# 移除 markdown code block 的輔助函數
+def strip_code_block_and_space(text: str) -> str:
+    # 砍 code block
+    cleaned = re.sub(r"^```[a-zA-Z]*\n", "", text)
+    cleaned = re.sub(r"\n?```$", "", cleaned)
+    # 砍全型、半型、no-break 空白
+    cleaned = cleaned.strip().replace('\u3000', '').replace('\xa0', '')
+    return cleaned
         
 class GameService:
     """
@@ -54,7 +71,9 @@ class GameService:
         self.agent_factory = agent_factory
         self.tools_repo = tools_repo
 
-    def start_game(self) -> ArticleSubmissionResponse:
+    # ========================== 開始遊戲 ==========================
+
+    def start_game(self, request: Optional[GameStartRequest] = None) -> GameStartResponse:
         """
         開始遊戲，初始化遊戲狀態。
         1. 產生唯一的 session_id
@@ -88,7 +107,6 @@ class GameService:
         platform_names = ["Facebook", "Instagram", "Thread"]
         audiences = ["年輕族群", "中年族群", "老年族群"]
         random.shuffle(audiences)
-
         platforms = [{"name": name, "audience": audience} for name, audience in zip(platform_names, audiences)]
         
         # 建立 GameSetup 紀錄
@@ -116,31 +134,406 @@ class GameService:
             is_completed=False
         )
               
-        # 呼叫 AI 回合
-        ai_request = FakeNewsAgentRequest(
+        # 進入 AI 先攻回合
+        ai_request = AiTurnRequest(session_id=session_id, round_number=round_number)
+        ai_response = self.ai_turn(ai_request)
+        return GameStartResponse(**ai_response.model_dump())
+
+    # ========================== AI 回合 ==========================
+    
+    def ai_turn(self, request: AiTurnRequest) -> AiTurnResponse:
+        return self._generic_turn(
+            actor="ai",
+            session_id=request.session_id,
+            round_number=request.round_number,
+            article=None,
+            tool_used=[],
+            tool_list=None
+        )
+    
+    # ========================== 玩家回合 ==========================
+
+    def player_turn(self, request: PlayerTurnRequest) -> PlayerTurnResponse:
+        return self._generic_turn(
+            actor="player",
+            session_id=request.session_id,
+            round_number=request.round_number,
+            article=request.article,
+            tool_used=request.tool_used or [],
+            tool_list=request.tool_list
+        )
+
+    # ========================== 下一回合 ==========================
+
+    def start_next_round(self, request: StartNextRoundRequest) -> StartNextRoundResponse:
+        """
+        進入下一回合，內部自動 +1，建立新狀態並啟動 AI 行動。
+        """
+        session_id = request.session_id
+        
+        # 查詢目前最大回合數，並自動 +1
+        last_round = self.round_repo.get_latest_round_by_session(session_id)
+        if not last_round:
+            raise BusinessLogicError("找不到上一回合紀錄")
+        round_number = last_round.round_number + 1
+
+        # 建立新回合的 PlatformState
+        platforms = self.setup_repo.get_by_session_id(session_id).platforms
+        self.state_repo.create_all_platforms_states(
             session_id=session_id,
             round_number=round_number,
+            platforms=platforms
         )
-        ai_response = self.ai_turn(ai_request)
-
-        # 組成 ArticleSubmissionResponse
-        return ArticleSubmissionResponse(
-            session_id=ai_response.session_id,
+        
+        # 建立 GameRound
+        self.round_repo.create_game_round(
+            session_id=session_id,
             round_number=round_number,
-            article=ai_response.article,
-            actor=ai_response.actor,
-            trust_change=ai_response.trust_change,
-            reach_count=ai_response.reach_count,
-            spread_change=ai_response.spread_change,
-            platform_setup=platforms,  # 這是初始化時的 platforms
-            platform_status=ai_response.platform_status,
-            tool_list=ai_response.tool_list,
-            tool_used=ai_response.tool_used,
-            effectiveness=ai_response.effectiveness,
-            simulated_comments=ai_response.simulated_comments
+            is_completed=False
+        )
+        # 直接呼叫 AI 先攻
+        ai_request = AiTurnRequest(session_id=session_id, round_number=round_number)
+        ai_response = self.ai_turn(ai_request)
+        return StartNextRoundResponse(**ai_response.model_dump())
+
+    # ========================== 回合主邏輯（共用） ==========================
+
+    def _generic_turn(
+        self,
+        actor: str,
+        session_id: str,
+        round_number: int,
+        article: Optional[ArticleMeta],
+        tool_used: Optional[List[ToolUsed]],
+        tool_list: Optional[List[Dict[str, Any]]]
+    ):
+        """
+        回合主流程（AI/玩家共用）。AI回合自動產生貼文；玩家回合用戶提供貼文與工具。
+        """
+        if not self.agent_factory:
+            raise BusinessLogicError("系統未設定 Agent Factory")
+
+        # 取得三平台設定
+        platforms_info = self.setup_repo.get_by_session_id(session_id).platforms
+
+        # ======== AI 回合邏輯 ========
+        if actor == "ai":
+            ai_platform_info = random.choice(platforms_info)
+            target_platform = ai_platform_info["name"]
+            target_audience = ai_platform_info["audience"]
+            # 取兩則新聞
+            news_1 = self.news_repo.get_random_active_news()
+            news_2 = self.news_repo.get_random_active_news()
+            # 工具（這邊可擴充取得 AI 可用工具）
+            all_tools = []
+            tool_used = []
+            used_tool_descriptions = "無可用工具"
+            # TODO: 這邊要從 tools_repo 取得所有可用工具
+            """
+            if hasattr(self, 'tools_repo') and self.tools_repo is not None:
+                all_tools = self.tools_repo.get_all_tools()
+                tool_used = [tool for tool in all_tools if tool.get("applicable_to") in ["ai", "both"]]
+                used_tool_descriptions = ", ".join([t.get("description") for t in tool_used if t.get("description")])
+            """
+
+            # 準備 prompt 變數
+            variables = {
+                "news_1": news_1.content,
+                "news_1_veracity": news_1.veracity,
+                "news_2": news_2.content,
+                "news_2_veracity": news_2.veracity,
+                "target_platform": target_platform,
+                "target_audience": target_audience,
+                "used_tool_descriptions": used_tool_descriptions
+            }
+
+            # 呼叫 FakeNewsAgent 生成假新聞
+            try:
+                result = self.agent_factory.run_agent_by_name(
+                session_id=session_id,
+                agent_name="fake_news_agent",
+                variables=variables,
+                input_text="input_text"
+                )
+
+                # 統一解析 output
+                if isinstance(result, dict):
+                    result_data = result
+                elif isinstance(result, str):
+                    cleaned = strip_code_block_and_space(result)
+                    logger.debug("[FakeNewsAgent] 淨化後內容：%r", cleaned)
+
+                    try:
+                        result_data = json.loads(cleaned)
+                    except Exception:
+                        raise BusinessLogicError("FakeNewsAgent 回傳格式錯誤，無法解析 JSON")
+                else:
+                    raise BusinessLogicError("FakeNewsAgent 回傳了不支援的格式")
+
+                # 組成 ArticleMeta
+                article = ArticleMeta(
+                    title=result_data.get("title"),
+                    content=result_data.get("content"),
+                    polished_content=None,
+                    image_url=result_data.get("image_url"),
+                    source=news_1.source, # 只給一個
+                    author="ai",
+                    published_date=datetime.now().isoformat(),
+                    target_platform=target_platform,  
+                    requirement=None,
+                    veracity=result_data.get("veracity")  
+                )
+            except ResourceNotFoundError:
+                raise ResourceNotFoundError(
+                    message="找不到 FakeNewsAgent",
+                    resource_type="agent",
+                    resource_id="FakeNewsAgent"
+                )
+            except Exception as e:
+                raise BusinessLogicError(f"生成假新聞過程發生錯誤: {str(e)}")
+      
+        # ======== 玩家回合邏輯 ========
+        else:
+            all_tools = tool_list or []
+            # 玩家自己決定 target_platform
+            target_platform = article.target_platform
+
+        # 建立 ActionRecord
+        action = self.action_repo.create_action_record(
+            session_id=session_id,
+            round_number=round_number,
+            actor=actor,
+            platform=target_platform,
+            content=article.content
         )
 
+        # AI: 更新 GameRound news_id
+        if actor == "ai":
+            self.round_repo.update_game_round(
+                session_id=session_id,
+                round_number=round_number,
+                news_id=getattr(news_1, "news_id", None),
+            )
+
+        # 工具倍率計算（預設 1.0，這裡可擴充）
+        trust_multiplier = 1.0
+        spread_multiplier = 1.0
+
+        # GM 評分
+        gm_result = self.game_master(
+            session_id=session_id,
+            round_number=round_number,
+            article=article,
+            platform=target_platform,
+            trust_multiplier=trust_multiplier,
+            spread_multiplier=spread_multiplier
+        )
+        trust_change = gm_result["trust_change"]
+        spread_change = gm_result["spread_change"]
+        reach_count = gm_result["reach_count"]
+        platform_status = gm_result["platform_status"]
+        effectiveness = gm_result.get("effectiveness")
+        simulated_comments = gm_result.get("simulated_comments")
+
+        # 更新 ActionRecord
+        self.action_repo.update_effectiveness(
+            action_id=action.id,
+            trust_change=trust_change,
+            spread_change=spread_change,
+            reach_count=reach_count,
+            effectiveness=effectiveness,
+            simulated_comments=simulated_comments
+        )
+
+        # 更新 PlatformState
+        for state in platform_status:
+            self.state_repo.update_platform_state(
+                session_id=session_id,
+                round_number=round_number,
+                platform_name=state["platform_name"],
+                player_trust=state["player_trust"],
+                ai_trust=state["ai_trust"],
+                spread_rate=state["spread"]
+            )
+
+        # 玩家回合才設 is_completed
+        if actor == "player":
+            self.round_repo.update_game_round(
+                session_id=session_id,
+                round_number=round_number,
+                news_id=None,
+                is_completed=True
+            )
+
+        # Output 結構整理（去掉 article veracity, AI 不顯示 target_platform）
+        article_dict = article.model_dump()
+        article_dict["veracity"] = None
+        if actor == "ai":
+            article_dict["target_platform"] = None
+        article_safe = ArticleMeta.model_validate(article_dict)
+        platform_status_objs = [self.platform_status_from_dict(ps) for ps in platform_status]
+
+        # Response 組裝
+        response_dict = dict(
+            session_id=session_id,
+            round_number=round_number,
+            actor=actor,
+            article=article_safe,
+            trust_change=trust_change,
+            reach_count=reach_count,
+            spread_change=spread_change,
+            platform_setup=platforms_info,
+            platform_status=platform_status_objs,
+            tool_used=tool_used or [],
+            tool_list=all_tools,
+            effectiveness=effectiveness,
+            simulated_comments=simulated_comments
+        )
+        # 輸出對應型別
+        if actor == "ai":
+            return AiTurnResponse(**response_dict)
+        else:
+            return PlayerTurnResponse(**response_dict)
+   
+    # ========================== GM 評分 ==========================
+    def game_master(
+        self,   
+        session_id: str,
+        round_number: int,
+        article: ArticleMeta,
+        platform: str,
+        trust_multiplier: float = 1.0,
+        spread_multiplier: float = 1.0,
+    ) -> dict:
+        """
+        GameMaster：僅負責計算/回傳評分，不做任何 DB 寫入。
+    
+        Args:
+            session_id: 遊戲場次 ID
+            round_number: 回合數
+            article: ArticleMeta（本回合發文的所有欄位）
+            platform: 本回合發文的平台名稱
+            trust_multiplier: 工具倍率，影響信任值變化
+            spread_multiplier: 工具倍率，影響傳播率變化
+    
+        Returns:
+            dict: 包含本回合評分結果，格式如下：
+                {
+                    "trust_change": int,         # 本回合造成的信任值變化
+                    "spread_change": int,        # 本回合造成的傳播率變化
+                    "reach_count": int,          # 本回合的觸及人數
+                    "platform_status": [         # 各平台最新狀態
+                        {
+                            "platform_name": str,
+                            "player_trust": int,
+                            "ai_trust": int,
+                            "spread": int
+                        },
+                        ...
+                    ]
+                }
+    
+        流程說明：
+            1. 取得三平台與受眾組合
+            2. 取得三平台當前狀態
+            3. 組成平台摘要字串，傳給 GM agent
+            4. 呼叫 GameMaster agent 進行評分
+            5. 解析回傳結果，回傳評分與平台狀態
+        """  
+        
+        if not self.agent_factory:
+            raise BusinessLogicError("系統未設定 Agent Factory")
+    
+        # === 從 GameSetup 撈出三個平台與對應受眾 ===
+        game_setup = self.setup_repo.get_by_session_id(session_id)
+        platforms_info = game_setup.platforms  # JSON 欄位：list of {"name": ..., "audience": ...}
+        audience_map = {p["name"]: p["audience"] for p in platforms_info}
+
+        # === 撈出三個平台當前狀態 ===
+        platform_states = self.state_repo.get_by_session_and_round(
+            session_id=session_id,
+            round_number=round_number
+        )
+
+        # === 組成平台摘要字串給 agent 參考（含受眾）===
+        platform_state_summary = "\n".join([
+            f"{s.platform_name}（受眾：{audience_map.get(s.platform_name)}） | 玩家信任: {s.player_trust} | AI信任: {s.ai_trust} | 傳播率: {s.spread_rate}%"
+            for s in platform_states
+        ])
+
+        if article.polished_content:
+            article.content = article.polished_content
+
+        # === 準備傳給 GM agent 的變數 ===
+        variables = {
+            "title": article.title,
+            "content": article.content,
+            "image_url": article.image_url,
+            "source": article.source,
+            "veracity": article.veracity,
+            "target_platform": platform,
+            "author": article.author,
+            "trust_multiplier": trust_multiplier,
+            "spread_multiplier": spread_multiplier,
+            "platform_state_summary": platform_state_summary,
+            "round_number": round_number
+        }
+
+        # === 呼叫 GameMaster Agent 評分 ===
+        try:
+            result = self.agent_factory.run_agent_by_name(
+                session_id=session_id,
+                agent_name="game_master_agent",
+                variables=variables,
+                input_text="input_text"
+            )
+
+            # 嘗試解析回傳 JSON 結果
+            if isinstance(result, dict):
+                result_data = result
+            elif isinstance(result, str):
+                cleaned = strip_code_block_and_space(result)
+                logger.debug("[GameMasterAgent] 淨化後內容：%r", cleaned)
+                try:
+                    result_data = json.loads(cleaned)
+                except Exception as e:
+                    raise BusinessLogicError(f"GameMasterAgent 回傳格式錯誤，無法解析 JSON: {repr(cleaned)} | {str(e)}")
+            else:
+                # 強制賦值，避免後面用到 cleaned 變數未定義
+                cleaned = None
+                raise BusinessLogicError("GameMasterAgent 回傳了不支援的格式")
+
+    
+            # 基本資料與可選欄位
+            return {
+                "trust_change": result_data.get("trust_change", 0),
+                "spread_change": result_data.get("spread_change", 0),
+                "reach_count": result_data.get("reach_count", 0),
+                "platform_status": result_data.get("platform_status", []),
+                "effectiveness": result_data.get("effectiveness"),
+                "simulated_comments": result_data.get("simulated_comments")
+            }
+        except ResourceNotFoundError:
+            raise ResourceNotFoundError(
+                message="找不到 GameMasterAgent",
+                resource_type="agent",
+                resource_id="GameMasterAgent"
+            )
+
+        except Exception as e:
+            raise BusinessLogicError(f"GameMaster 評分過程發生錯誤: {str(e)}")
+
+    @staticmethod
+    def platform_status_from_dict(ps: dict) -> PlatformStatus:
+        return PlatformStatus(
+            platform_name=ps["platform_name"],
+            player_trust=ps["player_trust"],
+            ai_trust=ps["ai_trust"],
+            spread_rate=ps["spread"]
+        )
                 
+    # ========== 新聞潤稿 ==========
+
     def polish_news(self, request: NewsPolishRequest) -> NewsPolishResponse:
         """
         使用 AI 系統當物潤稿新聞內容。
@@ -237,357 +630,3 @@ class GameService:
         except Exception as e:
             # 其他錯誤
             raise BusinessLogicError(f"潤稿過程發生錯誤: {str(e)}")
-
-
-    def ai_turn(self, request: FakeNewsAgentRequest) -> ArticleSubmissionResponse:
-        """
-        AI 回合主流程：生成假新聞，評分並更新狀態，最後回傳本回合結果。
-    
-        Args:
-            request: FakeNewsAgentRequest
-                - session_id: 遊戲識別碼
-                - round_number: 回合數
-                - tool_list: 可選，AI 可用的工具清單（通常由後端自動取得）
-    
-        Returns:
-            ArticleSubmissionResponse: 本回合的回傳資料，包含以下欄位：
-                - session_id: 遊戲識別碼
-                - round_number: 回合數
-                - actor: 行動者（"ai"）
-                - article: ArticleMeta，AI 發布的假新聞內容
-                - trust_change: 本回合造成的信任值變化
-                - reach_count: 本回合的觸及人數
-                - spread_change: 本回合造成的傳播率變化
-                - platform_setup: 平台與受眾的組合（初始化時的 platforms）
-                - platform_status: 所有平台目前的狀態（信任值、傳播率等）
-                - tool_list: 所有可用工具的名稱、描述及啟用狀況
-                - tool_used: 本回合實際使用的工具（如有）
-    
-        流程說明：
-            1. 隨機選擇一個平台與受眾組合
-            2. 隨機選取兩則新聞作為生成素材
-            3. 整理可用工具描述
-            4. 呼叫 FakeNewsAgent 產生假新聞
-            5. 建立 AI 的 ActionRecord
-            6. 呼叫 game_master() 進行評分
-            7. 更新 ActionRecord 與 PlatformState
-            8. 回傳本回合所有資訊
-        """
-        if not self.agent_factory:
-            raise BusinessLogicError("系統未設定 Agent Factory")
-        session_id = request.session_id
-        if session_id is None:
-            raise BusinessLogicError("session_id 必須由前端傳入")
-        round_number = request.round_number
-        if round_number is None:
-            raise BusinessLogicError("round_number 必須由前端傳入")
-        
-         # 2. 取得三平台設定，隨機選一組
-        platforms_info = self.setup_repo.get_by_session_id(session_id).platforms
-        ai_platform_info = random.choice(platforms_info)
-        ai_platform = ai_platform_info["name"]
-        target_audience = ai_platform_info["audience"]
-
-         # 3. 隨機選兩則新聞，取得 veracity
-        news_1 = self.news_repo.get_random_active_news()
-        news_2 = self.news_repo.get_random_active_news()
-
-        # 4. 準備工具描述（applicable_to in ["ai", "both"]）
-        # TODO: 這邊要從 tools_repo 取得所有可用工具
-        """
-        if hasattr(self, 'tools_repo') and self.tools_repo is not None:
-            all_tools = self.tools_repo.get_all_tools()
-            tool_used = [tool for tool in all_tools if tool.get("applicable_to") in ["ai", "both"]]
-            used_tool_descriptions = ", ".join([t.get("description") for t in tool_used if t.get("description")])
-        else:
-            all_tools = []
-            tool_used = []
-            used_tool_descriptions = "無可用工具"
-        """
-        # all_tools, tool_used 先設為空的
-        all_tools = []
-        tool_used = []
-        used_tool_descriptions = "無可用工具" # 暫時先用這個
-       
-        # 5. 準備 FakeNewsAgent prompt 變數
-        variables = {
-            "news_1": news_1.content,
-            "news_1_veracity": news_1.veracity,
-            "news_2": news_2.content,
-            "news_2_veracity": news_2.veracity,
-            "target_platform": ai_platform,
-            "target_audience": target_audience,
-            "used_tool_descriptions": used_tool_descriptions
-        }
-
-        # 6. 呼叫 FakeNewsAgent 產生假新聞
-        try:
-            result = self.agent_factory.run_agent_by_name(
-            session_id=session_id,
-            agent_name="fake_news_agent",
-            variables=variables,
-            input_text="input_text"
-            )
-
-            # 統一解析 output
-            if isinstance(result, dict):
-                result_data = result
-            elif isinstance(result, str):
-                try:
-                    result_data = json.loads(result)
-                except Exception:
-                    raise BusinessLogicError("FakeNewsAgent 回傳格式錯誤，無法解析 JSON")
-            else:
-                raise BusinessLogicError("FakeNewsAgent 回傳了不支援的格式")
-
-            # 7. 組成 ArticleMeta
-            article = ArticleMeta(
-                title=result_data.get("title"),
-                content=result_data.get("content"),
-                polished_content=None,
-                image_url=result_data.get("image_url"),
-                source=news_1.source, # 只給一個
-                author="ai",
-                published_date=datetime.now().isoformat(),
-                target_platform=ai_platform,  
-                requirement=None,
-                veracity=result_data.get("veracity")  
-            )
-        except ResourceNotFoundError:
-            raise ResourceNotFoundError(
-                message="找不到 FakeNewsAgent",
-                resource_type="agent",
-                resource_id="FakeNewsAgent"
-            )
-        except Exception as e:
-            raise BusinessLogicError(f"生成假新聞過程發生錯誤: {str(e)}")
-
-        # 8. 建立 AI 的 ActionRecord（僅初步，之後補全）
-        action = self.action_repo.create_action_record(
-            session_id=session_id,
-            round_number=round_number,
-            actor="ai",
-            platform=ai_platform,
-            content=article.content
-        )
-        
-        # 更新 GameRound 的 news_id
-        self.round_repo.update_game_round(
-            session_id=session_id,
-            round_number=round_number,
-            news_id=news_1.news_id,  # 使用第一則新聞的 ID
-        )
-        
-        # 工具倍率計算（由你設計規則，這裡範例直接設 1.0）
-        trust_multiplier = 1.0  # TODO: 根據工具選擇計算
-        spread_multiplier = 1.0  # TODO: 根據工具選擇計算
-        
-        # TODO: AI 的 UsageTool 紀錄還沒弄~~~~~~~
-
-        # 9. 呼叫 game_master() 評分
-        gm_result = self.game_master(
-            session_id=session_id,
-            round_number=round_number,
-            article=article,
-            platform=ai_platform,
-            trust_multiplier=trust_multiplier,
-            spread_multiplier=spread_multiplier            
-        )
-        
-        trust_change = gm_result["trust_change"]
-        spread_change = gm_result["spread_change"]
-        reach_count = gm_result["reach_count"]
-        platform_status = gm_result["platform_status"]
-        effectiveness = gm_result.get("effectiveness")
-        simulated_comments = gm_result.get("simulated_comments")
-
-        # 10. 更新 AI ActionRecord：補上 GM 結果
-        self.action_repo.update_effectiveness(
-            action_id=action.id,
-            trust_change=trust_change,
-            spread_change=spread_change,
-            reach_count=reach_count,
-            effectiveness=effectiveness,
-            simulated_comments=simulated_comments
-        )
-
-        # 11. 更新 PlatformState（只針對三平台同步更新，根據 GM 回傳結果）
-        for state in platform_status:
-            self.state_repo.update_platform_state(
-                session_id=session_id,
-                round_number=round_number,
-                platform_name=state["platform_name"],
-                ai_trust=state["ai_trust"],  
-                spread_rate=state["spread"]       
-            )
-        
-        # 將 platform_status 轉換為 PlatformStatus 物件
-        platform_status_objs = [self.platform_status_from_dict(ps) for ps in platform_status]
-        
-        # 過濾 target_platform 跟 veracity
-        article_dict = article.model_dump()
-        article_dict["target_platform"] = None
-        article_dict["veracity"] = None
-        article_safe = ArticleMeta.model_validate(article_dict)
-
-        # 12. 組成 ArticleSubmissionResponse，回傳本回合所有欄位
-        return ArticleSubmissionResponse(
-            session_id=session_id,
-            round_number=round_number,
-            actor="ai",
-            article=article_safe,
-            trust_change=trust_change,
-            reach_count=reach_count,
-            spread_change=spread_change,
-            platform_setup=self.setup_repo.get_by_session_id(session_id).platforms,  # 取得平台+受眾組合
-            platform_status=platform_status_objs,
-            tool_used=tool_used,
-            tool_list=all_tools,
-            effectiveness=effectiveness,
-            simulated_comments=simulated_comments
-        )
-
-    def game_master(
-        self,   
-        session_id: str,
-        round_number: int,
-        article: ArticleMeta,
-        platform: str,
-        trust_multiplier: float = 1.0,
-        spread_multiplier: float = 1.0,
-    ) -> dict:
-        """
-        GameMaster：僅負責計算/回傳評分，不做任何 DB 寫入。
-    
-        Args:
-            session_id: 遊戲場次 ID
-            round_number: 回合數
-            article: ArticleMeta（本回合發文的所有欄位）
-            platform: 本回合發文的平台名稱
-            trust_multiplier: 工具倍率，影響信任值變化
-            spread_multiplier: 工具倍率，影響傳播率變化
-    
-        Returns:
-            dict: 包含本回合評分結果，格式如下：
-                {
-                    "trust_change": int,         # 本回合造成的信任值變化
-                    "spread_change": int,        # 本回合造成的傳播率變化
-                    "reach_count": int,          # 本回合的觸及人數
-                    "platform_status": [         # 各平台最新狀態
-                        {
-                            "platform_name": str,
-                            "player_trust": int,
-                            "ai_trust": int,
-                            "spread": int
-                        },
-                        ...
-                    ]
-                }
-    
-        流程說明：
-            1. 取得三平台與受眾組合
-            2. 取得三平台當前狀態
-            3. 組成平台摘要字串，傳給 GM agent
-            4. 呼叫 GameMaster agent 進行評分
-            5. 解析回傳結果，回傳評分與平台狀態
-        """  
-        
-        if not self.agent_factory:
-            raise BusinessLogicError("系統未設定 Agent Factory")
-    
-        # === 從 GameSetup 撈出三個平台與對應受眾 ===
-        game_setup = self.setup_repo.get_by_session_id(session_id)
-        platforms_info = game_setup.platforms  # JSON 欄位：list of {"name": ..., "audience": ...}
-        audience_map = {p["name"]: p["audience"] for p in platforms_info}
-
-        # === 撈出三個平台當前狀態 ===
-        platform_states = self.state_repo.get_by_session_and_round(
-            session_id=session_id,
-            round_number=round_number
-        )
-
-        # === 組成平台摘要字串給 agent 參考（含受眾）===
-        platform_state_summary = "\n".join([
-            f"{s.platform_name}（受眾：{audience_map.get(s.platform_name)}） | 玩家信任: {s.player_trust} | AI信任: {s.ai_trust} | 傳播率: {s.spread_rate}%"
-            for s in platform_states
-        ])
-
-        if article.polished_content:
-            article.content = article.polished_content
-
-        # === 準備傳給 GM agent 的變數 ===
-        variables = {
-            "title": article.title,
-            "content": article.content,
-            "image_url": article.image_url,
-            "source": article.source,
-            "veracity": article.veracity,
-            "target_platform": platform,
-            "author": article.author,
-            "trust_multiplier": trust_multiplier,
-            "spread_multiplier": spread_multiplier,
-            "platform_state_summary": platform_state_summary,
-            "round_number": round_number
-        }
-
-        # === 呼叫 GameMaster Agent 評分 ===
-        try:
-            result = self.agent_factory.run_agent_by_name(
-                session_id=session_id,
-                agent_name="game_master_agent",
-                variables=variables,
-                input_text="input_text"
-            )
-
-            # 嘗試解析回傳 JSON 結果
-            if isinstance(result, str):
-                result_data = json.loads(result)
-            elif isinstance(result, dict):
-                result_data = result
-            else:
-                raise BusinessLogicError("GameMasterAgent 回傳格式錯誤，無法辨識")
-
-            # === 提取回傳數值 ===
-            trust_change = result_data.get("trust_change", 0)
-            spread_change = result_data.get("spread_change", 0)
-            reach_count = result_data.get("reach_count", 0)
-            new_platform_statuses = result_data.get("platform_status", [])  # 應為三筆 dict
-            effectiveness = result_data.get("effectiveness")
-            simulated_comments = result_data.get("simulated_comments")
-
-            # 檢查每筆 platform_status 必含 platform_name
-            for ps in new_platform_statuses:
-                assert "platform_name" in ps and "player_trust" in ps and "ai_trust" in ps and "spread" in ps, \
-                    "platform_status 每筆需有 platform_name, player_trust, ai_trust, spread"
-
-            # === 回傳結果 ===
-            return {
-                "trust_change": trust_change,
-                "spread_change": spread_change,
-                "reach_count": reach_count,
-                "platform_status": new_platform_statuses,
-                "effectiveness": effectiveness,
-                "simulated_comments": simulated_comments
-            }
-
-        except ResourceNotFoundError:
-            raise ResourceNotFoundError(
-                message="找不到 GameMasterAgent",
-                resource_type="agent",
-                resource_id="GameMasterAgent"
-            )
-
-        except Exception as e:
-            raise BusinessLogicError(f"GameMaster 評分過程發生錯誤: {str(e)}")
-
-    @staticmethod
-    def platform_status_from_dict(ps: dict) -> PlatformStatus:
-        return PlatformStatus(
-            platform_name=ps["platform_name"],
-            player_trust=ps["player_trust"],
-            ai_trust=ps["ai_trust"],
-            spread_rate=ps["spread"]
-        )
-        """
-        將平台狀態字典轉換為 PlatformStatus 物件。
-        """

--- a/src/application/services/game_service.py
+++ b/src/application/services/game_service.py
@@ -187,7 +187,8 @@ class GameService:
             result = self.agent_factory.run_agent_by_name(
                 session_id=request.session_id,
                 agent_name="news_polish_agent", 
-                variables=variables
+                variables=variables,
+                input_text="input_text"
             )
             
             # 當用 structured_output 時，有可能是字典或JSON字符串
@@ -324,7 +325,8 @@ class GameService:
             result = self.agent_factory.run_agent_by_name(
             session_id=session_id,
             agent_name="fake_news_agent",
-            variables=variables
+            variables=variables,
+            input_text="input_text"
             )
 
             # 統一解析 output
@@ -533,7 +535,8 @@ class GameService:
             result = self.agent_factory.run_agent_by_name(
                 session_id=session_id,
                 agent_name="game_master_agent",
-                variables=variables
+                variables=variables,
+                input_text="input_text"
             )
 
             # 嘗試解析回傳 JSON 結果

--- a/src/application/services/game_service.py
+++ b/src/application/services/game_service.py
@@ -371,7 +371,7 @@ class GameService:
         if actor == "ai":
             article_dict["target_platform"] = None
         article_safe = ArticleMeta.model_validate(article_dict)
-        platform_status_objs = [self.platform_status_from_dict(ps) for ps in platform_status]
+        platform_status_objs = [self.platform_status_from_dict(ps).model_dump() for ps in platform_status]
 
         # Response 組裝
         response_dict = dict(
@@ -389,6 +389,10 @@ class GameService:
             effectiveness=effectiveness,
             simulated_comments=simulated_comments
         )
+        logger.debug("platform_status 原始內容: %r", platform_status)
+        logger.debug("platform_status 組裝成物件後: %r", platform_status_objs)
+        logger.debug("response_dict 最終平台數: %d", len(response_dict["platform_status"]))
+
         # 輸出對應型別
         if actor == "ai":
             return AiTurnResponse(**response_dict)

--- a/src/infrastructure/alembic/env.py
+++ b/src/infrastructure/alembic/env.py
@@ -7,6 +7,7 @@ from alembic import context
 
 # 匯入 model metadata
 from src.infrastructure.database.models.base import Base
+from src.infrastructure.database.models import action_record, agent, game_round, game_setup, news, platform_state, tools, toolusage
 
 # this is the Alembic Config object, which provides
 # access to the values within the .ini file in use.

--- a/src/infrastructure/alembic/versions/20250521_215849_caf500575720_同步_model_更新.py
+++ b/src/infrastructure/alembic/versions/20250521_215849_caf500575720_同步_model_更新.py
@@ -1,0 +1,40 @@
+"""同步 model 更新
+
+Revision ID: caf500575720
+Revises: 1f3d5b72234b
+Create Date: 2025-05-21 21:58:49.760069
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision: str = 'caf500575720'
+down_revision: Union[str, None] = '1f3d5b72234b'
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    # 將 game_rounds.news_id 改成 nullable
+    op.alter_column(
+        'game_rounds',                   
+        'news_id',                       
+        existing_type=sa.Integer(),      
+        nullable=True                    # 允許為 NULL
+    ) # 將 news_id 改為可為 None（等新聞生出來再更新）
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    # 將 game_rounds.news_id 改成 not nullable
+    op.alter_column(
+        'game_rounds',                   
+        'news_id',                       
+        existing_type=sa.Integer(),      
+        nullable=False                   # 不允許為 NULL
+    ) # 將 news_id 改為不可以 None

--- a/src/infrastructure/database/action_record_repo.py
+++ b/src/infrastructure/database/action_record_repo.py
@@ -134,6 +134,7 @@ class ActionRecordRepository(BaseRepository[ActionRecord]):
         spread_change: Optional[int] = None,  # 設為可選
         effectiveness: Optional[str] = None,  # 設為可選
         reach_count: Optional[int] = None,  # 設為可選
+        simulated_comments: Optional[list] = None,  # 設為可選
         db: Optional[Session] = None
     ):
         """

--- a/src/infrastructure/database/action_record_repo.py
+++ b/src/infrastructure/database/action_record_repo.py
@@ -165,5 +165,7 @@ class ActionRecordRepository(BaseRepository[ActionRecord]):
             action.effectiveness = effectiveness
         if reach_count is not None:
             action.reach_count = reach_count
+        if simulated_comments is not None:
+            action.simulated_comments = simulated_comments
 
         db.commit()

--- a/src/infrastructure/database/game_round_repo.py
+++ b/src/infrastructure/database/game_round_repo.py
@@ -73,7 +73,7 @@ class GameRoundRepository(BaseRepository[GameRound]):
         self,
         session_id: str,
         round_number: int,
-        news_id: int,
+        news_id: Optional[int] = None,
         is_completed: bool = False,
         db: Optional[Session] = None
     ) -> GameRound:
@@ -83,7 +83,7 @@ class GameRoundRepository(BaseRepository[GameRound]):
         Args:
             session_id: 遊戲識別碼
             round_number: 回合編號（從 1 開始）
-            news_id: 本回合所使用的新聞 ID
+            news_id: 創建時還不需要輸入
             is_completed: 是否為已完成狀態（預設 False）
             db: 資料庫 Session（自動注入）
 
@@ -100,32 +100,32 @@ class GameRoundRepository(BaseRepository[GameRound]):
             db=db
         )
 
+    
     @with_session
-    def create_first_round(
+    def update_game_round(
         self,
         session_id: str,
         round_number: int,
-        news_id: int,
+        news_id: Optional[int] = None,
+        is_completed: Optional[bool] = False,  
         db: Optional[Session] = None
     ) -> GameRound:
         """
-        建立第一回合的遊戲記錄。
+        更新遊戲回合的狀態或新聞 ID。
 
         Args:
             session_id: 遊戲識別碼
-            round_number: 回合數（通常為 1）
-            news_id: 本回合所使用的新聞 ID
-            db: 資料庫 Session
+            round_number: 回合編號
+            news_id: 新聞 ID（可選）
+            is_completed: 是否已完成（可選）
+            db: 資料庫 Session（自動注入）
 
         Returns:
-            新創建的 GameRound 實體
+            更新後的 GameRound 實體
         """
-        return self.create(
-            {
-                "session_id": session_id,
-                "round_number": round_number,
-                "news_id": news_id,
-                "is_completed": False,
-            },
-            db=db
-        )
+        game_round = self.get_by_session_and_round(session_id, round_number, db)
+        if news_id is not None:
+            game_round.news_id = news_id
+        if is_completed is not None:
+            game_round.is_completed = is_completed
+        return self.update(game_round, db=db)

--- a/src/infrastructure/database/models/game_round.py
+++ b/src/infrastructure/database/models/game_round.py
@@ -50,7 +50,7 @@ class GameRound(Base, TimeStampMixin):
     news_id = Column(
         Integer,
         ForeignKey("news.news_id"),
-        nullable=False,
+        nullable=True, 
         comment="本回合所使用的新聞 ID"
     )
 

--- a/src/infrastructure/database/models/platform_state.py
+++ b/src/infrastructure/database/models/platform_state.py
@@ -45,7 +45,7 @@ class PlatformState(Base, TimeStampMixin):
     platform_name = Column(
         String(32),
         nullable=False,
-        comment="平台名稱（如 Facebook、Twitter）"
+        comment="平台名稱（如 Facebook、Instagram）"
     )
 
     # 玩家信任值

--- a/src/infrastructure/database/models/platform_state.py
+++ b/src/infrastructure/database/models/platform_state.py
@@ -17,7 +17,7 @@ class PlatformState(Base, TimeStampMixin):
     - **id**: 主鍵，自動遞增。
     - **session_id**: 對應遊戲場次 ID，對應 GameSetup 表的主鍵。
     - **round_number**: 當前回合數。
-    - **platform_name**: 平台名稱（如 Facebook、Twitter）。
+    - **platform_name**: 平台名稱（如 "Facebook", "Instagram", "Thread"）。
     - **player_trust**: 玩家在此平台的信任值（0~100）。
     - **ai_trust**: AI 在此平台的信任值（0~100）。
     - **spread_rate**: 傳播率，百分比（整數 0~100）。

--- a/src/infrastructure/database/platform_state_repo.py
+++ b/src/infrastructure/database/platform_state_repo.py
@@ -74,45 +74,7 @@ class PlatformStateRepository(BaseRepository[PlatformState]):
                 resource_id=f"{session_id}-{round_number}"
             )
         return results
-
-    @with_session
-    def create_platform_state(
-        self,
-        session_id: str,
-        round_number: int,
-        platform_name: str,
-        player_trust: int,
-        ai_trust: int,
-        spread_rate: int,
-        db: Optional[Session] = None
-    ) -> PlatformState:
-        """
-        創建新的平台狀態紀錄。
-
-        Args:
-            session_id: 所屬遊戲 ID
-            round_number: 所屬回合數
-            platform_name: 平台名稱
-            player_trust: 玩家信任度（0~100）
-            ai_trust: AI 信任度（0~100）
-            spread_rate: 傳播率（整數百分比）
-            db: 可選的資料庫 Session
-
-        Returns:
-            新創建的 PlatformState 實體
-        """
-        return self.create(
-            {
-                "session_id": session_id,
-                "round_number": round_number,
-                "platform_name": platform_name,
-                "player_trust": player_trust,
-                "ai_trust": ai_trust,
-                "spread_rate": spread_rate,
-            },
-            db=db
-        )
-
+    
     @with_session
     def get_states_by_session(
         self,
@@ -130,31 +92,108 @@ class PlatformStateRepository(BaseRepository[PlatformState]):
             該 session_id 下所有平台的狀態列表
         """
         return db.query(PlatformState).filter_by(session_id=session_id).all()
-
+    
     @with_session
-    def create_initial_states(
+    def get_state_by_session_round_and_platform_name(
         self,
         session_id: str,
+        round_number: int,
+        platform_name: str,
+        db: Optional[Session] = None
+    ) -> Optional[PlatformState]:  
+        return db.query(PlatformState).filter_by(
+            session_id=session_id,
+            round_number=round_number,
+            platform_name=platform_name
+        ).first()
+
+    @with_session
+    def create_platform_state(
+        self,
+        session_id: str,
+        round_number: int,
+        platform_name: str,
+        player_trust: int,
+        ai_trust: int,
+        spread_rate: int,
+        db: Optional[Session] = None 
+    ) -> PlatformState:
+        """
+        創建一個新的平台狀態紀錄。
+        如果不是第一回合，會自動從上一回合抓信任度和傳播率，否則預設 50。
+        """
+        if round_number > 1:
+            prev_state = self.get_state_by_session_round_and_platform_name(
+                session_id=session_id,
+                round_number=round_number - 1,
+                platform_name=platform_name,
+                db=db
+            )
+        else:
+            prev_state = None
+
+        platform_player_trust = player_trust if player_trust is not None else (prev_state.player_trust if prev_state else 50)
+        platform_ai_trust = ai_trust if ai_trust is not None else (prev_state.ai_trust if prev_state else 50)
+        platform_spread_rate = spread_rate if spread_rate is not None else (prev_state.spread_rate if prev_state else 50)
+
+        return self.create(
+            {
+                "session_id": session_id,
+                "round_number": round_number,
+                "platform_name": platform_name,
+                "player_trust": platform_player_trust,
+                "ai_trust": platform_ai_trust,
+                "spread_rate": platform_spread_rate,
+            },
+            db=db
+        )
+        
+    @with_session
+    def create_all_platforms_states(
+        self,
+        session_id: str,
+        round_number: int,
         platforms: List[dict],
+        player_trust: int,
+        ai_trust: int,
+        spread_rate: int,
         db: Optional[Session] = None
     ):
         """
-        建立初始平台狀態，信任值與傳播率皆為預設值。
-
-        Args:
-            session_id: 遊戲識別碼
-            platforms: 平台與受眾設定（JSON list）
-            db: 可選的資料庫 Session
+        一次創建所有平台的狀態紀錄。
         """
+        previous_states_dict = {}
+        if round_number > 1:
+            try:
+                previous_states = self.get_by_session_and_round(
+                    session_id=session_id,
+                    round_number=round_number - 1,
+                    db=db
+                )
+                previous_states_dict = {
+                    state.platform_name: state for state in previous_states
+                }
+            except ResourceNotFoundError:
+                # 如果不是第一回合卻查不到上一回合，才 raise
+                raise
+
         for platform in platforms:
+            if "name" not in platform:
+                raise ValueError("Each platform must have a 'name' key.")
+
+            previous_state = previous_states_dict.get(platform["name"])
+            platform_player_trust = player_trust if player_trust is not None else (previous_state.player_trust if previous_state else 50)
+            platform_ai_trust = ai_trust if ai_trust is not None else (previous_state.ai_trust if previous_state else 50)
+            platform_spread_rate = spread_rate if spread_rate is not None else (previous_state.spread_rate if previous_state else 50)
+
             self.create(
                 {
                     "session_id": session_id,
-                    "round_number": 1,
+                    "round_number": round_number,
                     "platform_name": platform["name"],
-                    "player_trust": 50,
-                    "ai_trust": 50,
-                    "spread_rate": 50,
+                    "player_trust": platform_player_trust,
+                    "ai_trust": platform_ai_trust,
+                    "spread_rate": platform_spread_rate,
                 },
                 db=db
             )
@@ -165,8 +204,9 @@ class PlatformStateRepository(BaseRepository[PlatformState]):
         session_id: str,
         round_number: int,
         platform_name: str,
-        trust_change_ai: int,
-        spread_change: int,
+        player_trust: int,
+        ai_trust: int,
+        spread_rate: int,
         db: Optional[Session] = None
     ):
         """
@@ -196,7 +236,33 @@ class PlatformStateRepository(BaseRepository[PlatformState]):
                 resource_id=f"{session_id}-{round_number}-{platform_name}"
             )
 
-        platform.ai_trust += trust_change_ai
-        platform.spread_rate += spread_change
+        player_trust = player_trust
+        ai_trust = ai_trust
+        spread_rate = spread_rate
         db.commit()
+    
+    @with_session    
+    def update_all_platforms_states(
+        self,
+        session_id: str,
+        round_number: int,
+        platform_status_list: List[dict],
+        db: Optional[Session] = None
+    ):
+        """
+        批次更新所有平台狀態。
+        platform_status_list: [
+            {"platform_name": ..., "ai_trust": ..., "spread": ...},
+            ...
+        ]
+        """
+        for state in platform_status_list:
+            self.update_platform_state(
+                session_id=session_id,
+                round_number=round_number,
+                platform_name=state["platform_name"],
+                ai_trust=state["ai_trust"],
+                spread_rate=state["spread"],
+                db=db
+            )
 

--- a/src/infrastructure/database/platform_state_repo.py
+++ b/src/infrastructure/database/platform_state_repo.py
@@ -236,10 +236,12 @@ class PlatformStateRepository(BaseRepository[PlatformState]):
                 resource_id=f"{session_id}-{round_number}-{platform_name}"
             )
 
-        player_trust = player_trust
-        ai_trust = ai_trust
-        spread_rate = spread_rate
+        # 這裡才是正確做法
+        platform.player_trust = player_trust
+        platform.ai_trust = ai_trust
+        platform.spread_rate = spread_rate
         db.commit()
+
     
     @with_session    
     def update_all_platforms_states(

--- a/src/infrastructure/database/platform_state_repo.py
+++ b/src/infrastructure/database/platform_state_repo.py
@@ -113,9 +113,9 @@ class PlatformStateRepository(BaseRepository[PlatformState]):
         session_id: str,
         round_number: int,
         platform_name: str,
-        player_trust: int,
-        ai_trust: int,
-        spread_rate: int,
+        player_trust: Optional[int]=None,
+        ai_trust: Optional[int]=None,
+        spread_rate: Optional[int]=None,
         db: Optional[Session] = None 
     ) -> PlatformState:
         """
@@ -154,9 +154,9 @@ class PlatformStateRepository(BaseRepository[PlatformState]):
         session_id: str,
         round_number: int,
         platforms: List[dict],
-        player_trust: int,
-        ai_trust: int,
-        spread_rate: int,
+        player_trust: int=None,
+        ai_trust: int=None,
+        spread_rate: int=None,
         db: Optional[Session] = None
     ):
         """


### PR DESCRIPTION
## 內容說明（必填）

* feat: 建立 ai\_turn, player\_turn, start\_next\_round 三個遊戲流程 API
* feat: 整合 FakeNewsAgent 與 GameMasterAgent，改為由 AgentFactory 動態注入
* feat: 設計通用回傳格式 BaseRoundResponse，統一 AI/玩家回合的 response 結構
* feat: 擴充 DTO 結構（ArticleMeta、ToolUsed、PlatformStatus 等）對應遊戲資料欄位
* feat: 新增 GameRoundRepository 與 PlatformStateRepository 所需邏輯（如 get\_latest\_round、update\_all\_platforms\_states）
* refactor: 將 game\_service.py 中回合邏輯抽象為 `_generic_turn()`，集中控制與重用
* chore: 建立 Alembic migration，使 game\_round.news\_id nullable
* chore: 優化 PlatformState 建立與更新流程，支援回合狀態遞移

---

## 注意事項（如有）

* 回合流程已集中於 `_generic_turn()`，後續請依此結構擴充 AI 與玩家邏輯
* Alembic migration 涉及 `game_rounds.news_id` 欄位 nullable，請所有開發者執行：

  ```bash
  alembic upgrade head
  ```