### PR TITLE
Fix/simulated comments agent

### DIFF
--- a/src/api/routes/base.py
+++ b/src/api/routes/base.py
@@ -126,6 +126,7 @@ from src.infrastructure.database.action_record_repo import ActionRecordRepositor
 from src.infrastructure.database.game_round_repo import GameRoundRepository
 from src.infrastructure.database.tool_repo import ToolRepository
 from src.infrastructure.database.tool_usage_repo import ToolUsageRepository
+from src.infrastructure.database.article_polish_record_repo import ArticlePolishRecordRepository
 
 
 def get_agent_service(db: Session = Depends(get_db)) -> AgentService:
@@ -150,5 +151,6 @@ def get_game_service(db: Session = Depends(get_db), agent_factory: AgentFactory 
         round_repo=GameRoundRepository(),
         tool_repo=ToolRepository(),
         tool_usage_repo=ToolUsageRepository(),
-        agent_factory=agent_factory
+        agent_factory=agent_factory,
+        polish_repo=ArticlePolishRecordRepository()
     )

--- a/src/application/dto/game_dto.py
+++ b/src/application/dto/game_dto.py
@@ -426,3 +426,15 @@ class NewsPolishResponse(BaseModel):
                 "reasoning": "修改重點包括：加入吸引人的標題、使用更生動的描述語言、強調環保意識、突出成就感與使命感。"
             }
         }
+
+
+class SimulateCommentsRequest(BaseModel):
+    session_id: str = Field(..., description="遊戲 Session ID")
+    article: "ArticleMeta" = Field(..., description="要產生留言的新聞資料")
+    actor: str = Field(..., description="新聞發布者（ai/player）")
+    round_number: int = Field(..., description="回合數")
+    platform: str = Field(..., description="平台名稱")
+    audience: Optional[str] = Field(None, description="平台受眾")
+    
+class SimulateCommentsResponse(BaseModel):
+    comments: List[str] = Field(default_factory=list, description="產生的留言清單")

--- a/src/application/services/game_service.py
+++ b/src/application/services/game_service.py
@@ -15,6 +15,7 @@ from src.infrastructure.database.platform_state_repo import PlatformStateReposit
 from src.infrastructure.database.news_repo import NewsRepository
 from src.infrastructure.database.action_record_repo import ActionRecordRepository
 from src.infrastructure.database.game_round_repo import GameRoundRepository
+from src.infrastructure.database.article_polish_record_repo import ArticlePolishRecordRepository
 from src.domain.logic.agent_factory import AgentFactory
 from src.domain.logic.game_initialization import GameInitializationLogic
 from src.domain.logic.ai_turn import AiTurnLogic
@@ -50,6 +51,7 @@ class GameService:
         tool_repo: ToolRepository,
         tool_usage_repo: ToolUsageRepository,
         agent_factory: Optional[AgentFactory] = None,
+        polish_repo: Optional[ArticlePolishRecordRepository] = None
     ):
         self.setup_repo = setup_repo
         self.state_repo = state_repo
@@ -59,7 +61,8 @@ class GameService:
         self.agent_factory = agent_factory
         self.tool_repo = tool_repo
         self.tool_usage_repo = tool_usage_repo
-        
+        self.polish_repo = polish_repo
+
         # Domain logic instances
         self.game_init_logic = GameInitializationLogic()
         self.ai_turn_logic = AiTurnLogic()
@@ -75,7 +78,7 @@ class GameService:
         )
         self.game_state_manager = GameStateManager(
             setup_repo, state_repo, action_repo, tool_usage_repo,
-            self.game_state_logic, self.gm_logic, self.tool_effect_logic, self.agent_factory
+            self.game_state_logic, self.gm_logic, self.tool_effect_logic, self.agent_factory, polish_repo
         )
         self.tool_availability_logic = ToolAvailabilityLogic(tool_repo)
         self.response_converter = ResponseConverter(setup_repo, self.tool_availability_logic)

--- a/src/application/services/game_service.py
+++ b/src/application/services/game_service.py
@@ -37,6 +37,7 @@ from src.domain.logic.response_converter import ResponseConverter
 from src.domain.logic.tool_availability_logic import ToolAvailabilityLogic
 from src.domain.logic.game_end_logic import GameEndLogic
 from src.config.game_config import game_config
+from src.domain.logic.simulate_comments import SimulateCommentsLogic
         
 class GameService:
     def __init__(
@@ -66,10 +67,11 @@ class GameService:
         self.game_state_logic = GameStateLogic()
         self.player_action_logic = PlayerActionLogic()
         self.tool_effect_logic = ToolEffectLogic()
+        self.simulate_comments_logic = SimulateCommentsLogic(agent_factory)
         
         # New refactored components
         self.turn_execution_logic = TurnExecutionLogic(
-            self.ai_turn_logic, self.tool_repo, self.agent_factory, self.news_repo
+            self.ai_turn_logic, self.tool_repo, self.agent_factory, self.news_repo, self.simulate_comments_logic
         )
         self.game_state_manager = GameStateManager(
             setup_repo, state_repo, action_repo, tool_usage_repo,

--- a/src/domain/logic/game_master.py
+++ b/src/domain/logic/game_master.py
@@ -8,7 +8,8 @@ class GameMasterLogic:
         article: ArticleMeta, 
         platform: Platform,
         all_platforms: List[Platform],
-        round_number: int
+        round_number: int,
+        simulated_comments: List[str]
     ) -> Dict[str, Any]:
         platform_summary = "\n".join([
             f"{p.name}（受眾：{p.audience}） | 玩家信任: {p.player_trust.value} | AI信任: {p.ai_trust.value} | 傳播率: {p.spread_rate.value}%"
@@ -28,7 +29,8 @@ class GameMasterLogic:
             "trust_multiplier": 1.0,
             "spread_multiplier": 1.0,
             "platform_state_summary": platform_summary,
-            "round_number": round_number
+            "round_number": round_number,
+            "simulated_comments": simulated_comments
         }
     
     def parse_gm_result(self, gm_result: Dict[str, Any]) -> Dict[str, Any]:

--- a/src/domain/logic/game_state_manager.py
+++ b/src/domain/logic/game_state_manager.py
@@ -45,9 +45,6 @@ class GameStateManager:
         self.tool_effect_logic = tool_effect_logic
         self.agent_factory = agent_factory
         self.polish_repo = polish_repo
-        print("DEBUG polish_repo is:", polish_repo)
-        if polish_repo is None:
-            raise RuntimeError("polish_repo is None, check your DI chain")
 
     def rebuild_game_state(self, session_id: str, round_number: int):
         """重建遊戲狀態"""

--- a/src/domain/logic/game_state_manager.py
+++ b/src/domain/logic/game_state_manager.py
@@ -63,7 +63,8 @@ class GameStateManager:
             game, 
             turn_result.article, 
             turn_result.target_platform, 
-            turn_result.round_number
+            turn_result.round_number,
+            turn_result.simulated_comments
         )
         
         logger.debug(f"Original GM evaluation for {turn_result.actor}", extra={
@@ -108,8 +109,9 @@ class GameStateManager:
             round_number=turn_result.round_number,
             actor=turn_result.actor,
             platform=turn_result.target_platform,
-            content=turn_result.article.content
-        )
+            content=turn_result.article.content,
+            simulated_comments=turn_result.simulated_comments
+            )
         
         # 2. 更新行動效果
         self.action_repo.update_effectiveness(
@@ -118,7 +120,6 @@ class GameStateManager:
             spread_change=gm_result.spread_change,
             reach_count=gm_result.reach_count,
             effectiveness=gm_result.effectiveness,
-            simulated_comments=gm_result.simulated_comments
         )
         
         # 3. 更新平台狀態
@@ -156,12 +157,12 @@ class GameStateManager:
         })
         
         return action_record.id
-    
-    def _get_gm_evaluation(self, game, article, target_platform, round_number) -> GameMasterAgentResponse:
+
+    def _get_gm_evaluation(self, game, article, target_platform, round_number, simulated_comments) -> GameMasterAgentResponse:
         """獲取 GM 評估"""
         target_platform_obj = game.get_platform(target_platform)
         variables = self.gm_logic.prepare_evaluation_variables(
-            article, target_platform_obj, game.platforms, round_number
+            article, target_platform_obj, game.platforms, round_number, simulated_comments
         )
         
         gm_response: GameMasterAgentResponse = self.agent_factory.run_agent_by_name(

--- a/src/domain/logic/simulate_comments.py
+++ b/src/domain/logic/simulate_comments.py
@@ -1,0 +1,56 @@
+from typing import Any, Dict, Optional
+from src.application.dto.game_dto import SimulateCommentsRequest, SimulateCommentsResponse
+
+class SimulateCommentsLogic:
+    """
+    群眾留言生成邏輯 - Domain Layer
+    """
+    def __init__(self, agent_factory):
+        self.agent_factory = agent_factory
+
+    def prepare_simulate_comments_variables(
+        self, request: SimulateCommentsRequest
+    ) -> Dict[str, Any]:
+
+        content = request.article.polished_content or request.article.content
+
+        variables = {
+            "title": request.article.title,
+            "content": content,
+            "platform": request.platform,
+            "audience": request.audience,
+            "actor": request.actor,
+            "round_number": request.round_number,
+        }
+        
+        return variables
+
+    def parse_simulate_comments_result(self, result: Any) -> SimulateCommentsResponse:
+        # 處理 agent 回傳格式
+        if isinstance(result, SimulateCommentsResponse):
+            return result
+        if isinstance(result, dict):
+            comments = result.get("comments")
+            if isinstance(comments, list):
+                return SimulateCommentsResponse(comments=comments)
+            elif isinstance(comments, str):
+                return SimulateCommentsResponse(comments=[comments])
+        if isinstance(result, list):
+            return SimulateCommentsResponse(comments=result)
+        if isinstance(result, str):
+            lines = [x.strip() for x in result.splitlines() if x.strip()]
+            return SimulateCommentsResponse(comments=lines)
+        return SimulateCommentsResponse(comments=[])
+
+    def generate_comments(
+        self, request: SimulateCommentsRequest, input_text: str = "input_text"
+    ) -> SimulateCommentsResponse:
+        variables = self.prepare_simulate_comments_variables(request)
+        result = self.agent_factory.run_agent_by_name(
+            session_id=request.session_id,
+            agent_name="simulate_comments_agent",
+            variables=variables,
+            input_text=input_text,
+            response_model=SimulateCommentsResponse
+        )
+        return self.parse_simulate_comments_result(result)

--- a/src/infrastructure/alembic/versions/20250525_192101_07467a6b338e_建立_article_polish_record_資料表.py
+++ b/src/infrastructure/alembic/versions/20250525_192101_07467a6b338e_建立_article_polish_record_資料表.py
@@ -1,0 +1,36 @@
+"""建立 article_polish_record 資料表
+
+Revision ID: 07467a6b338e
+Revises: 3e3973af9d66
+Create Date: 2025-05-25 19:21:01.013420
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = '07467a6b338e'
+down_revision: Union[str, None] = '3e3973af9d66'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade():
+    op.create_table(
+        'article_polish_records',
+        sa.Column('id', sa.Integer(), primary_key=True, autoincrement=True, comment="主鍵，自動遞增"),
+        sa.Column('session_id', sa.String(length=64), nullable=False, comment="對應的遊戲 session ID"),
+        sa.Column('round_number', sa.Integer(), nullable=False, comment="對應的回合編號"),
+        sa.Column('original_content', sa.Text(), nullable=False, comment="原始文章內容"),
+        sa.Column('polished_content', sa.Text(), nullable=False, comment="潤飾後的文章內容"),
+        sa.Column('created_at', sa.DateTime(), nullable=True),
+        sa.Column('updated_at', sa.DateTime(), nullable=True),
+    )
+    op.create_index('idx_sessionid_round', 'article_polish_records', ['session_id', 'round_number'])
+
+def downgrade():
+    op.drop_index('idx_sessionid_round', table_name='article_polish_records')
+    op.drop_table('article_polish_records')

--- a/src/infrastructure/database/article_polish_record_repo.py
+++ b/src/infrastructure/database/article_polish_record_repo.py
@@ -1,0 +1,134 @@
+from typing import Optional, List
+from sqlalchemy.orm import Session
+
+from src.infrastructure.database.base_repo import BaseRepository
+from src.infrastructure.database.models.article_polish_record import ArticlePolishRecord
+from src.infrastructure.database.utils import with_session
+from src.utils.exceptions import ResourceNotFoundError
+
+
+class ArticlePolishRecordRepository(BaseRepository[ArticlePolishRecord]):
+    """
+    ArticlePolishRecord 資料庫 Repository 類，對應潤飾前後文章的資料表。
+    支援基本 CRUD 操作，預期主要用途為新增與查詢。
+
+    用法示例:
+    ```python
+    repo = ArticlePolishRecordRepository()
+    # 建立新潤飾記錄
+    record = repo.create_record(
+        session_id="game123",
+        round_number=2,
+        original_content="原始內容",
+        polished_content="潤飾後內容"
+    )
+    # 查詢某場次某回合的潤飾記錄
+    records = repo.get_by_session_and_round("game123", 2)
+    ```
+    """
+    model = ArticlePolishRecord
+
+    @with_session
+    def create_polish_record(
+        self,
+        session_id: str,
+        round_number: int,
+        original_content: str,
+        polished_content: str,
+        db: Optional[Session] = None
+    ) -> ArticlePolishRecord:
+        """
+        新增一筆潤飾記錄。
+        """
+        return self.create(
+            {
+                "session_id": session_id,
+                "round_number": round_number,
+                "original_content": original_content,
+                "polished_content": polished_content,
+            },
+            db=db
+        )
+
+    @with_session
+    def get_by_session_and_round(
+        self,
+        session_id: str,
+        round_number: int,
+        db: Optional[Session] = None
+    ) -> List[ArticlePolishRecord]:
+        """
+        查詢指定 session_id 與 round_number 的所有潤飾記錄。
+        找不到時回傳空列表。
+        """
+        return (
+            db.query(self.model)
+            .filter_by(session_id=session_id, round_number=round_number)
+            .order_by(self.model.created_at.asc())
+            .all()
+        )
+
+    @with_session
+    def get_or_raise(
+        self,
+        session_id: str,
+        round_number: int,
+        db: Optional[Session] = None
+    ) -> List[ArticlePolishRecord]:
+        """
+        查詢指定 session_id 與 round_number 的所有潤飾記錄。
+        若查無資料則丟 ResourceNotFoundError。
+        """
+        result = self.get_by(
+            db=db,
+            session_id=session_id,
+            round_number=round_number
+        )
+        if not result:
+            raise ResourceNotFoundError(
+                message=f"No ArticlePolishRecords found for session_id='{session_id}' round={round_number}",
+                resource_type="article_polish_record",
+                resource_id=f"{session_id}-{round_number}"
+            )
+        return result
+
+    @with_session
+    def update_polished_content(
+        self,
+        record_id: int,
+        polished_content: str,
+        db: Optional[Session] = None
+    ) -> ArticlePolishRecord:
+        """
+        更新指定記錄的潤飾後內容。
+        """
+        record = db.query(ArticlePolishRecord).filter_by(id=record_id).first()
+        if not record:
+            raise ResourceNotFoundError(
+                message=f"ArticlePolishRecord with id={record_id} not found",
+                resource_type="article_polish_record",
+                resource_id=record_id
+            )
+        record.polished_content = polished_content
+        db.commit()
+        db.refresh(record)
+        return record
+
+    @with_session
+    def delete_record(
+        self,
+        record_id: int,
+        db: Optional[Session] = None
+    ):
+        """
+        刪除指定 id 的潤飾記錄。
+        """
+        record = db.query(ArticlePolishRecord).filter_by(id=record_id).first()
+        if not record:
+            raise ResourceNotFoundError(
+                message=f"ArticlePolishRecord with id={record_id} not found",
+                resource_type="article_polish_record",
+                resource_id=record_id
+            )
+        db.delete(record)
+        db.commit()

--- a/src/infrastructure/database/models/article_polish_record.py
+++ b/src/infrastructure/database/models/article_polish_record.py
@@ -1,0 +1,44 @@
+from sqlalchemy import Column, Integer, String, Text, ForeignKey, Index
+from .base import Base, TimeStampMixin
+
+class ArticlePolishRecord(Base, TimeStampMixin):
+    __tablename__ = "article_polish_records"
+
+    id = Column(
+        Integer,
+        primary_key=True,
+        autoincrement=True,
+        comment="主鍵，自動遞增"
+    )
+    
+    session_id = Column(
+        String(64),
+        ForeignKey("article_polish_records.session_id"),
+        nullable=False,
+        comment="對應的遊戲 session ID"
+    )
+    
+    round_number = Column(
+        Integer,
+        nullable=False,
+        comment="對應的回合編號"
+    )
+    
+    original_content = Column(
+        Text,
+        nullable=False,
+        comment="原始文章內容"
+    )
+    
+    polished_content = Column(
+        Text,
+        nullable=False,
+        comment="潤飾後的文章內容"
+    )
+
+    __table_args__ = (
+        Index('idx_sessionid_round', 'session_id', 'round_number'),
+    )
+
+    def __repr__(self):
+        return f"<ArticlePolishRecord(id={self.id}, session_id={self.session_id}, round_number={self.round_number}, original_content={self.original_content}, polished_content={self.polished_content})>"


### PR DESCRIPTION
## 內容說明

* **feat: 紀錄潤稿**

  * 新增 `article_polish_records` 資料表，專責紀錄每回合玩家的原始內容 (`content`) 及潤色內容 (`polished_content`)。
  * `ArticleMeta` 模型調整，正式支援 `content`（原稿）與 `polished_content`（潤色稿）雙欄位，API 流程同步更新。
  * 玩家送出前可先呼叫 `/polish-news` 取得潤色稿，前端支援原稿/潤色稿同時顯示與送出，後端全程存底。
  * DI chain 補入 polish\_repo 依賴，確保資料一致性與流程串接。


* **feat: simulate\_comments agent 串接與 GM 評分邏輯優化**

  * 新增 SimulateCommentsRequest/Response DTO，讓 AI/玩家行動都能獲得專屬模擬留言，流程更彈性。
  * GameMasterAgent 評分流程整合留言資料，支援更完整的遊戲評分邏輯。

* **chore: Alembic migration**

  * 新增 article\_polish\_records 資料表、必要欄位、索引與欄位註解。

---

## 注意事項

* migrate 前請先執行 Alembic migration 指令並驗證新表正常運作。
